### PR TITLE
gitignore scripts/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ output.wav
 
 *-draft.md
 tasks/
+
+# local bench/dev scripts (also in .Rbuildignore; never shipped or committed)
+scripts/


### PR DESCRIPTION
scripts/ holds local bench/dev scripts (already in .Rbuildignore, never shipped). Ignore it in git too so the untracked scripts/bench/ residue can't be committed by accident. Flagged in corteza's PR #16 review.