### PR TITLE
GPT-2 added tokens: turbo paralinguistic tags

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: chatterbox
 Title: Text-to-Speech Using Chatterbox TTS Engine
-Version: 0.1.0.10
+Version: 0.1.0.11
 Authors@R:
     c(person("Troy", "Hernandez", role = c("aut", "cre"),
              email = "troy@cornball.ai",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# chatterbox 0.1.0.11 (development)
+
+- Turbo's GPT-2 tokenizer now emits the paralinguistic/emotion tags
+  (`[sigh]`, `[laugh]`, `[whispering]`, `[cough]`, ...) as single special
+  tokens. `load_gpt2_tokenizer()` builds an added-token split-list and
+  `tokenize_text_gpt2()` splits on it before BPE; previously the tags were
+  byte-BPE'd into `[`, `sigh`, `]` and never rendered.
+
 # chatterbox 0.1.0.10 (development)
 
 - New `t3_inference_turbo_jit()`: a TorchScript decode step for turbo's

--- a/R/tokenizer.R
+++ b/R/tokenizer.R
@@ -318,12 +318,22 @@ load_gpt2_tokenizer <- function(vocab_path, merges_path,
     # Load vocabulary (token string -> id)
     vocab <- jsonlite::fromJSON(vocab_path, simplifyVector = TRUE)
 
-    # Load added tokens if provided
+    # Load added tokens if provided. As well as putting them in the vocab
+    # (id lookup / decoding), keep a content->id map sorted longest-first
+    # so tokenize_text_gpt2() can split them out before BPE - otherwise the
+    # GPT-2 pre-tokenizer shatters "[sigh]" into "[", "sigh", "]" and the
+    # paralinguistic tag id is never emitted.
+    added_tokens <- integer(0)
     if (!is.null(added_tokens_path) && file.exists(added_tokens_path)) {
         added <- jsonlite::fromJSON(added_tokens_path, simplifyVector = TRUE)
         for (tok in names(added)) {
             vocab[[tok]] <- added[[tok]]
         }
+        contents <- names(added)
+        ids <- as.integer(added)
+        ord <- order(nchar(contents), decreasing = TRUE)
+        added_tokens <- ids[ord]
+        names(added_tokens) <- contents[ord]
     }
 
     # Build byte-to-unicode mapping (GPT-2 specific)
@@ -357,6 +367,7 @@ load_gpt2_tokenizer <- function(vocab_path, merges_path,
 
     list(vocab = vocab, bpe_ranks = bpe_ranks, byte_encoder = byte_encoder,
          byte_decoder = byte_decoder, id_to_token = id_to_token,
+         added_tokens = added_tokens,
          vocab_size = length(vocab), type = "gpt2")
 }
 
@@ -395,6 +406,30 @@ load_gpt2_tokenizer <- function(vocab_path, merges_path,
 #' @return Integer vector of token IDs
 #' @keywords internal
 tokenize_text_gpt2 <- function(tokenizer, text) {
+    # Split out added tokens (paralinguistic/emotion tags like [sigh],
+    # [laugh], [whispering]) first so each maps to its single id; BPE only
+    # runs on the text in between.
+    added_tokens <- tokenizer$added_tokens
+    if (is.null(added_tokens)) {
+        added_tokens <- integer(0)
+    }
+    all_ids <- integer(0)
+    for (seg in split_added_tokens(text, added_tokens)) {
+        if (!is.na(seg$id)) {
+            all_ids <- c(all_ids, seg$id)
+        } else {
+            all_ids <- c(all_ids, .gpt2_bpe_encode(tokenizer, seg$text))
+        }
+    }
+    all_ids
+}
+
+#' GPT-2 byte-level BPE for a plain text segment (no added-token handling)
+#' @param tokenizer GPT-2 tokenizer
+#' @param text Plain text segment
+#' @return Integer vector of token IDs
+#' @keywords internal
+.gpt2_bpe_encode <- function(tokenizer, text) {
     byte_encoder <- tokenizer$byte_encoder
     bpe_ranks <- tokenizer$bpe_ranks
     vocab <- tokenizer$vocab

--- a/inst/tinytest/test_gpt2_added_tokens.R
+++ b/inst/tinytest/test_gpt2_added_tokens.R
@@ -3,6 +3,30 @@
 # Tokenizer-only (no model), so it just needs the turbo files downloaded.
 library(chatterbox)
 
+# --- split_added_tokens(): core logic, always runs (no model files) ----------
+sp <- chatterbox:::split_added_tokens
+
+# Tag mid-text -> plain | tag(id) | plain
+segs <- sp("hello [sigh] world", c("[sigh]" = 50268L))
+expect_equal(length(segs), 3L)
+expect_equal(segs[[1]]$text, "hello ")
+expect_true(is.na(segs[[1]]$id))
+expect_equal(segs[[2]]$text, "[sigh]")
+expect_equal(segs[[2]]$id, 50268L)
+expect_equal(segs[[3]]$text, " world")
+expect_true(is.na(segs[[3]]$id))
+
+# Tag only -> single special segment
+only <- sp("[sigh]", c("[sigh]" = 50268L))
+expect_equal(length(only), 1L)
+expect_equal(only[[1]]$id, 50268L)
+
+# No tag present -> single plain segment
+none <- sp("just text", c("[sigh]" = 50268L))
+expect_equal(length(none), 1L)
+expect_true(is.na(none[[1]]$id))
+
+# --- turbo GPT-2 tokenizer end-to-end (needs the turbo files) -----------------
 if (turbo_models_available()) {
     tp <- get_turbo_model_paths()
     tok <- load_gpt2_tokenizer(tp$vocab, tp$merges, tp$added_tokens)

--- a/inst/tinytest/test_gpt2_added_tokens.R
+++ b/inst/tinytest/test_gpt2_added_tokens.R
@@ -1,0 +1,23 @@
+# Turbo's GPT-2 tokenizer must emit paralinguistic/emotion tags ([sigh],
+# [laugh], ...) as single special-token ids, not byte-BPE them into pieces.
+# Tokenizer-only (no model), so it just needs the turbo files downloaded.
+library(chatterbox)
+
+if (turbo_models_available()) {
+    tp <- get_turbo_model_paths()
+    tok <- load_gpt2_tokenizer(tp$vocab, tp$merges, tp$added_tokens)
+
+    expect_true(length(tok$added_tokens) >= 19L)
+
+    # Each tag is one token with its declared id (from added_tokens.json).
+    expect_equal(chatterbox:::tokenize_text_gpt2(tok, "[sigh]"), 50268L)
+    expect_equal(chatterbox:::tokenize_text_gpt2(tok, "[laugh]"), 50275L)
+    # A two-word tag still resolves to a single id.
+    expect_equal(length(chatterbox:::tokenize_text_gpt2(tok, "[clear throat]")),
+                 1L)
+
+    # In running text the tag is one id and the words around it still BPE.
+    ids <- chatterbox:::tokenize_text_gpt2(tok, "hello [sigh] world")
+    expect_true(50268L %in% ids)
+    expect_true(length(ids) > 1L)
+}

--- a/man/dot-gpt2_bpe_encode.Rd
+++ b/man/dot-gpt2_bpe_encode.Rd
@@ -1,0 +1,19 @@
+% tinyrox says don't edit this manually, but it can't stop you!
+\name{.gpt2_bpe_encode}
+\alias{.gpt2_bpe_encode}
+\title{GPT-2 byte-level BPE for a plain text segment (no added-token handling)}
+\usage{
+.gpt2_bpe_encode(tokenizer, text)
+}
+\arguments{
+\item{tokenizer}{GPT-2 tokenizer}
+
+\item{text}{Plain text segment}
+}
+\value{
+Integer vector of token IDs
+}
+\description{
+GPT-2 byte-level BPE for a plain text segment (no added-token handling)
+}
+\keyword{internal}


### PR DESCRIPTION
Turbo ships 19 paralinguistic/emotion tags ([sigh], [laugh], [whispering], [cough], ...) but the GPT-2 tokenizer byte-BPE'd them into pieces, so they never rendered. load_gpt2_tokenizer() now builds an added-token split-list and tokenize_text_gpt2() splits on it before BPE (mirroring the standard tokenizer). Adds an always-on split_added_tokens() test plus turbo-gated tokenizer tests; full test_package green (109). Version 0.1.0.11.