### PR TITLE
Fix turbo serve crash, garbled voice cloning, and GC-bound inference

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: chatterbox
 Title: Text-to-Speech Using Chatterbox TTS Engine
-Version: 0.1.0.12
+Version: 0.1.0.13
 Authors@R:
     c(person("Troy", "Hernandez", role = c("aut", "cre"),
              email = "troy@cornball.ai",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: chatterbox
 Title: Text-to-Speech Using Chatterbox TTS Engine
-Version: 0.1.0.14
+Version: 0.1.0.15
 Authors@R:
     c(person("Troy", "Hernandez", role = c("aut", "cre"),
              email = "troy@cornball.ai",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: chatterbox
 Title: Text-to-Speech Using Chatterbox TTS Engine
-Version: 0.1.0.13
+Version: 0.1.0.14
 Authors@R:
     c(person("Troy", "Hernandez", role = c("aut", "cre"),
              email = "troy@cornball.ai",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# chatterbox 0.1.0.14 (development)
+
+- `read_audio()` now detects the audio container from the file's magic
+  bytes (RIFF/WAVE, ID3, MP3 frame sync) instead of trusting the
+  extension. A reference saved as PCM/WAV but named `.mp3` (or vice
+  versa) previously ran the wrong decoder and produced NaN garbage,
+  silently corrupting voice cloning; it now decodes correctly.
+
 # chatterbox 0.1.0.13 (development)
 
 - `serve()` now caches each voice embedding (by reference path + mtime)

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
   meant gc ran on nearly every allocation once a model occupied more than
   20% of VRAM, which was 53% of inference wall time. The floor is now the
   model's footprint as a fraction of VRAM (4.1GB regular, 3.6GB turbo): e.g. a
-  16GB card gets 0.26 / 0.22, a 6GB card 0.68 / 0.60. `threshold_call_gc` is
+  16GB card gets 0.26 / 0.23, a 6GB card 0.68 / 0.60. `threshold_call_gc` is
   raised to 16000 MB. All set ahead of `cuda_is_available()`. Turbo is ~2x
   faster on a 16GB card (10.7s -> 5.3s for a 16s utterance). An explicit
   user-set option still wins. See torch's memory-management vignette.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# chatterbox 0.1.0.15 (development)
+
+- `chatterbox()` now tunes torch's CUDA garbage-collection rates before the
+  first CUDA op. torch reads `torch.cuda_allocator_reserved_rate` (and
+  `torch.threshold_call_gc`) once at lazy CUDA init; the 0.2 default floor
+  meant gc ran on nearly every allocation once a model occupied more than
+  20% of VRAM, which was 53% of inference wall time. The floor is now scaled
+  to the card (~0.26 on a 16GB card, ~0.75 on 6GB) and `threshold_call_gc`
+  raised to 16000 MB, both set ahead of `cuda_is_available()`. Turbo is ~2x
+  faster on a 16GB card (10.7s -> 5.3s for a 16s utterance). An explicit
+  user-set option still wins. See torch's memory-management vignette.
+
 # chatterbox 0.1.0.14 (development)
 
 - `read_audio()` now detects the audio container from the file's magic

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# chatterbox 0.1.0.13 (development)
+
+- `serve()` now caches each voice embedding (by reference path + mtime)
+  and reuses it across requests, instead of re-encoding the reference on
+  every `/v1/audio/speech` call. Per-request re-encoding churned voice
+  GPU tensors and raced the CUDA caching allocator, intermittently
+  producing NaN speaker conditioning - seen as a "missing value where
+  TRUE/FALSE needed" 500 and as degraded voice cloning (~33-50% of
+  requests on both an RTX 5060 Ti and a GTX 1660 Ti; 0 with the cache).
+  `trim_silence()` now raises a clear error instead of the cryptic one if
+  NaN audio ever reaches it.
+
 # chatterbox 0.1.0.12 (development)
 
 - `serve()` now uses the `jit` backend for turbo as well as standard (was

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,9 +4,10 @@
   first CUDA op. torch reads `torch.cuda_allocator_reserved_rate` (and
   `torch.threshold_call_gc`) once at lazy CUDA init; the 0.2 default floor
   meant gc ran on nearly every allocation once a model occupied more than
-  20% of VRAM, which was 53% of inference wall time. The floor is now scaled
-  to the card (~0.26 on a 16GB card, ~0.75 on 6GB) and `threshold_call_gc`
-  raised to 16000 MB, both set ahead of `cuda_is_available()`. Turbo is ~2x
+  20% of VRAM, which was 53% of inference wall time. The floor is now the
+  model's footprint as a fraction of VRAM (4.1GB regular, 3.6GB turbo): e.g. a
+  16GB card gets 0.26 / 0.22, a 6GB card 0.68 / 0.60. `threshold_call_gc` is
+  raised to 16000 MB. All set ahead of `cuda_is_available()`. Turbo is ~2x
   faster on a 16GB card (10.7s -> 5.3s for a 16s utterance). An explicit
   user-set option still wins. See torch's memory-management vignette.
 

--- a/R/audio_utils.R
+++ b/R/audio_utils.R
@@ -113,6 +113,11 @@ trim_silence <- function(samples, top_db = 20, frame_length = 2048L,
     }, numeric(1))
 
     ref <- max(power)
+    if (is.na(ref)) {
+        stop("trim_silence: NaN in reference-audio power - the voice encoding ",
+             "is corrupt (a CUDA allocator race can cause this); retry, or ",
+             "report if it persists", call. = FALSE)
+    }
     if (ref <= 0) {
         return(samples)
     }

--- a/R/audio_utils.R
+++ b/R/audio_utils.R
@@ -1,15 +1,47 @@
 # Audio utilities for chatterbox
 # Handles audio I/O, resampling, and mel spectrogram computation
 
+# Detect the real container from magic bytes, ignoring the file extension.
+# Voice libraries sometimes carry a .mp3 name on a real WAV (or vice versa);
+# running the wrong decoder yields silent NaN garbage, not an error. Returns
+# "wav", "mp3", or NA when the header is unrecognized.
+.sniff_audio_format <- function(path) {
+    con <- file(path, "rb")
+    on.exit(close(con))
+    magic <- readBin(con, "raw", n = 12L)
+    if (length(magic) < 2L) {
+        return(NA_character_)
+    }
+    if (length(magic) >= 12L &&
+        identical(magic[1:4], charToRaw("RIFF")) &&
+        identical(magic[9:12], charToRaw("WAVE"))) {
+        return("wav")
+    }
+    if (length(magic) >= 3L && identical(magic[1:3], charToRaw("ID3"))) {
+        return("mp3")
+    }
+    # MP3 frame sync: 0xFF followed by 0b111xxxxx
+    if (magic[1] == as.raw(0xFF) &&
+        bitwAnd(as.integer(magic[2]), 0xE0L) == 0xE0L) {
+        return("mp3")
+    }
+    NA_character_
+}
+
 #' Read audio file
 #'
 #' @param path Path to audio file (WAV or MP3 format)
 #' @return List with samples (numeric vector normalized to \[-1, 1\]) and sr (sample rate)
 #' @export
 read_audio <- function(path) {
-    ext <- tolower(tools::file_ext(path))
+    # Decode by actual content, not the extension (a mislabeled reference
+    # otherwise runs the wrong decoder and yields NaN garbage).
+    fmt <- .sniff_audio_format(path)
+    if (is.na(fmt)) {
+        fmt <- tolower(tools::file_ext(path))
+    }
 
-    if (ext == "mp3") {
+    if (fmt == "mp3") {
         # MP3 requires mpg123 system library
         wav <- tuneR::readMP3(path)
     } else {

--- a/R/serve.R
+++ b/R/serve.R
@@ -61,7 +61,7 @@
 #' @return Does not return normally; runs until interrupted.
 #' @export
 serve <- function(port = 7810L, device = "cuda", voices_dir = NULL,
-                  turbo = FALSE, timeout = 300L, max_body = 10L * 1024L^2,
+                  turbo = FALSE, timeout = 300L, max_body = 10L * 1024L ^ 2,
                   warmup = TRUE) {
     if (is.null(voices_dir)) {
         voices_dir <- Sys.getenv("TTS_VOICES_DIR", "~/.cornball/voices")
@@ -82,17 +82,17 @@ serve <- function(port = 7810L, device = "cuda", voices_dir = NULL,
         vfiles <- list.files(voices_dir, pattern = "\\.(wav|mp3|m4a|flac)$",
                              full.names = TRUE, ignore.case = TRUE)
         if (length(vfiles) > 0L) {
-            bk <- "jit"   # both standard (Llama) and turbo (GPT-2) have jit
+            bk <- "jit" # both standard (Llama) and turbo (GPT-2) have jit
             for (bucket in c(250L, 500L, 1000L)) {
                 message("Warming up CFM bucket ", bucket, " ...")
                 # Pin cfm_len so the tiny gen traces this bucket; without
                 # the pin, generate() would self-size every warmup to 250.
                 tryCatch(
-                    generate(model, "Warming up.", vfiles[1], backend = bk,
-                             traced = !isTRUE(model$turbo),
-                             cfm_len = 640L + 2L * bucket, max_new_tokens = 16L),
-                    error = function(e) message("warmup skipped: ",
-                                                conditionMessage(e))
+                         generate(model, "Warming up.", vfiles[1], backend = bk,
+                                  traced = !isTRUE(model$turbo),
+                                  cfm_len = 640L + 2L * bucket, max_new_tokens = 16L),
+                         error = function(e) message("warmup skipped: ",
+                        conditionMessage(e))
                 )
             }
             message("Warmup done (CFM buckets 250/500/1000 traced).")
@@ -106,27 +106,28 @@ serve <- function(port = 7810L, device = "cuda", voices_dir = NULL,
 
     repeat {
         con <- tryCatch(
-            socketAccept(srv, blocking = TRUE, open = "r+b",
-                         timeout = timeout),
-            error = function(e) {
-                message("accept error: ", conditionMessage(e))
-                Sys.sleep(0.5) # avoid a busy-spin on a bad server socket
-                NULL
-            }
+                        socketAccept(srv, blocking = TRUE, open = "r+b", timeout = timeout),
+                        error = function(e) {
+            message("accept error: ", conditionMessage(e))
+            Sys.sleep(0.5) # avoid a busy-spin on a bad server socket
+            NULL
+        }
         )
-        if (is.null(con)) next
+        if (is.null(con)) {
+            next
+        }
         tryCatch({
             req <- .serve_read_request(con, max_body)
             if (!is.null(req)) {
                 resp <- tryCatch(
-                    .serve_route(req, model, voices_dir),
-                    error = function(e) .serve_err(500L, conditionMessage(e))
+                                 .serve_route(req, model, voices_dir),
+                                 error = function(e) .serve_err(500L, conditionMessage(e))
                 )
                 .serve_send(con, resp$status, resp$content_type, resp$body)
             }
         },
-        error = function(e) message("request error: ", conditionMessage(e)),
-        finally = { try(close(con), silent = TRUE); gc() })  # gc per request; no empty_cache (warm pool)
+                 error = function(e) message("request error: ", conditionMessage(e)),
+                 finally = { try(close(con), silent = TRUE) ; gc() }) # gc per request; no empty_cache (warm pool)
     }
 }
 
@@ -141,39 +142,61 @@ serve <- function(port = 7810L, device = "cuda", voices_dir = NULL,
     max_header <- 65536L
     repeat {
         b <- readBin(con, "raw", n = 1L)
-        if (length(b) == 0L) return(NULL) # closed or timed out mid-header
+        if (length(b) == 0L) {
+            return(NULL) # closed or timed out mid-header
+        }
         buf <- c(buf, b)
         n <- length(buf)
-        if (n >= 4L && identical(buf[(n - 3L):n], term)) break
-        if (n > max_header) return(NULL)
+        if (n >= 4L && identical(buf[(n - 3L):n], term)) {
+            break
+        }
+        if (n > max_header) {
+            return(NULL)
+        }
     }
 
     lines <- strsplit(rawToChar(buf), "\r\n", fixed = TRUE)[[1]]
     req_line <- strsplit(lines[1], " ", fixed = TRUE)[[1]]
-    if (length(req_line) < 2L) return(NULL)
+    if (length(req_line) < 2L) {
+        return(NULL)
+    }
     method <- req_line[1]
     path <- req_line[2]
 
     hdr <- list()
     if (length(lines) > 1L) {
         for (ln in lines[-1L]) {
-            if (!nzchar(ln)) next
+            if (!nzchar(ln)) {
+                next
+            }
             pos <- regexpr(":", ln, fixed = TRUE)
-            if (pos < 1L) next
+            if (pos < 1L) {
+                next
+            }
             key <- tolower(trimws(substr(ln, 1L, pos - 1L)))
             hdr[[key]] <- trimws(substr(ln, pos + 1L, nchar(ln)))
         }
     }
 
     cl <- hdr[["content-length"]]
-    clen <- if (is.null(cl)) 0L else suppressWarnings(as.integer(cl))
-    if (length(clen) != 1L || is.na(clen) || clen < 0L) clen <- 0L
+    if (is.null(cl)) {
+        clen <- 0L
+    } else {
+        clen <- suppressWarnings(as.integer(cl))
+    }
+    if (length(clen) != 1L || is.na(clen) || clen < 0L) {
+        clen <- 0L
+    }
     if (clen > max_body) {
         return(list(method = method, path = path, headers = hdr,
                     body = raw(0), too_large = TRUE))
     }
 
-    body <- if (clen > 0L) .serve_read_n(con, clen) else raw(0)
+    if (clen > 0L) {
+        body <- .serve_read_n(con, clen)
+    } else {
+        body <- raw(0)
+    }
     list(method = method, path = path, headers = hdr, body = body)
 }
 
@@ -182,7 +205,9 @@ serve <- function(port = 7810L, device = "cuda", voices_dir = NULL,
     out <- raw(0)
     while (length(out) < n) {
         chunk <- readBin(con, "raw", n = n - length(out))
-        if (length(chunk) == 0L) break
+        if (length(chunk) == 0L) {
+            break
+        }
         out <- c(out, chunk)
     }
     out
@@ -190,16 +215,19 @@ serve <- function(port = 7810L, device = "cuda", voices_dir = NULL,
 
 # Write an HTTP/1.1 response and close (Connection: close).
 .serve_send <- function(con, status, content_type, body) {
-    if (is.character(body)) body <- charToRaw(body)
-    reason <- switch(as.character(status),
-        "200" = "OK", "400" = "Bad Request", "404" = "Not Found",
-        "405" = "Method Not Allowed", "413" = "Payload Too Large",
-        "500" = "Internal Server Error", "Unknown")
+    if (is.character(body)) {
+        body <- charToRaw(body)
+    }
+    reason <- switch(as.character(status), "200" = "OK",
+                     "400" = "Bad Request", "404" = "Not Found",
+                     "405" = "Method Not Allowed",
+                     "413" = "Payload Too Large",
+                     "500" = "Internal Server Error", "Unknown")
     head <- paste0(
-        sprintf("HTTP/1.1 %d %s\r\n", status, reason),
-        sprintf("Content-Type: %s\r\n", content_type),
-        sprintf("Content-Length: %d\r\n", length(body)),
-        "Connection: close\r\n\r\n")
+                   sprintf("HTTP/1.1 %d %s\r\n", status, reason),
+                   sprintf("Content-Type: %s\r\n", content_type),
+                   sprintf("Content-Length: %d\r\n", length(body)),
+                   "Connection: close\r\n\r\n")
     writeBin(c(charToRaw(head), body), con)
     flush(con)
 }
@@ -212,7 +240,11 @@ serve <- function(port = 7810L, device = "cuda", voices_dir = NULL,
     path <- sub("\\?.*$", "", req$path)
 
     if (identical(req$method, "GET") && path == "/health") {
-        tag <- if (isTRUE(model$turbo)) "chatterbox-turbo" else "chatterbox"
+        if (isTRUE(model$turbo)) {
+            tag <- "chatterbox-turbo"
+        } else {
+            tag <- "chatterbox"
+        }
         return(.serve_json(list(status = "ok", model = tag)))
     }
     if (identical(req$method, "GET") &&
@@ -247,14 +279,16 @@ serve <- function(port = 7810L, device = "cuda", voices_dir = NULL,
     # guessing), and batches within a per-card cap. Short input is one
     # chunk through the traced generate() path.
     gen_args <- list(model = model, text = body$input, voice = voice,
-                     backend = "jit",                      # jit for both
-                     traced = !isTRUE(model$turbo))        # CFM trace: standard only
+                     backend = "jit", # jit for both
+                     traced = !isTRUE(model$turbo)) # CFM trace: standard only
     # Forward optional request knobs when present, so clients can drive the
     # new behavior through the server.
     for (k in c("exaggeration", "cfg_weight", "temperature", "top_p",
                 "repetition_penalty", "max_new_tokens", "normalize_text",
                 "chunk_size", "max_batch")) {
-        if (!is.null(body[[k]])) gen_args[[k]] <- body[[k]]
+        if (!is.null(body[[k]])) {
+            gen_args[[k]] <- body[[k]]
+        }
     }
 
     res <- do.call(tts_chunked, gen_args)
@@ -283,13 +317,19 @@ serve <- function(port = 7810L, device = "cuda", voices_dir = NULL,
 
 # Resolve a voice name (or path) to a reference audio file.
 .serve_resolve_voice <- function(voice, voices_dir) {
-    if (file.exists(voice)) return(voice)
+    if (file.exists(voice)) {
+        return(voice)
+    }
     files <- list.files(voices_dir, pattern = "\\.(wav|mp3|m4a|flac)$",
                         full.names = TRUE, ignore.case = TRUE)
-    if (length(files) == 0L) return(NULL)
+    if (length(files) == 0L) {
+        return(NULL)
+    }
     names_no_ext <- tools::file_path_sans_ext(basename(files))
     idx <- match(tolower(voice), tolower(names_no_ext))
-    if (is.na(idx)) return(NULL)
+    if (is.na(idx)) {
+        return(NULL)
+    }
     files[idx]
 }
 
@@ -302,10 +342,9 @@ serve <- function(port = 7810L, device = "cuda", voices_dir = NULL,
 
 # Content-Type for an audio format extension.
 .serve_ctype <- function(fmt) {
-    switch(fmt,
-        mp3 = "audio/mpeg", wav = "audio/wav", ogg = "audio/ogg",
-        flac = "audio/flac", opus = "audio/opus", m4a = "audio/mp4",
-        "application/octet-stream")
+    switch(fmt, mp3 = "audio/mpeg", wav = "audio/wav", ogg = "audio/ogg",
+           flac = "audio/flac", opus = "audio/opus", m4a = "audio/mp4",
+           "application/octet-stream")
 }
 
 # JSON 200 response.

--- a/R/serve.R
+++ b/R/serve.R
@@ -6,6 +6,26 @@
 # invalidated). Requests are served one at a time, which is the natural fit for a
 # single-GPU TTS box.
 
+# Session cache for per-voice embeddings, keyed by reference path + mtime.
+# create_voice_embedding() re-encodes the reference (voice-encoder LSTM, S3Gen
+# tokenizer, embed_ref) on every call. Doing that per request churns voice GPU
+# tensors and races the CUDA caching allocator, which intermittently produces
+# NaN conditioning - surfacing as a hard-to-trace "missing value where
+# TRUE/FALSE needed" crash and as degraded voice cloning. Encoding each voice
+# once and reusing it removes the churn (and is faster).
+.serve_voice_cache <- new.env(parent = emptyenv())
+
+# Resolve a reference path to a cached voice_embedding, encoding on first use.
+.serve_voice_embedding <- function(model, voice_path) {
+    key <- paste(voice_path, file.info(voice_path)$mtime)
+    ve <- .serve_voice_cache[[key]]
+    if (is.null(ve)) {
+        ve <- create_voice_embedding(model, voice_path)
+        .serve_voice_cache[[key]] <- ve
+    }
+    ve
+}
+
 #' Serve chatterbox over HTTP
 #'
 #' Starts a blocking HTTP server that loads the chatterbox model once and answers
@@ -54,6 +74,8 @@ serve <- function(port = 7810L, device = "cuda", voices_dir = NULL,
     message("Loading chatterbox", if (turbo) " turbo" else "", " model on ",
             device, " ...")
     model <- chatterbox(device, turbo = turbo)
+    # Voice embeddings are model-specific; start each serve with a fresh cache.
+    rm(list = ls(.serve_voice_cache), envir = .serve_voice_cache)
     message("Model loaded. Voices dir: ", voices_dir)
 
     if (isTRUE(warmup)) {
@@ -215,12 +237,16 @@ serve <- function(port = 7810L, device = "cuda", voices_dir = NULL,
     if (is.null(voice_path)) {
         return(.serve_err(400L, paste0("voice not found: ", body$voice)))
     }
+    # Reuse the cached embedding instead of re-encoding the reference each
+    # request (see .serve_voice_cache: per-request encoding races the CUDA
+    # allocator and intermittently yields NaN conditioning).
+    voice <- .serve_voice_embedding(model, voice_path)
 
     # tts_chunked is the synthesis entry: it splits long input, sizes the
     # CFM per chunk from the tokens actually produced (no text-length
     # guessing), and batches within a per-card cap. Short input is one
     # chunk through the traced generate() path.
-    gen_args <- list(model = model, text = body$input, voice = voice_path,
+    gen_args <- list(model = model, text = body$input, voice = voice,
                      backend = "jit",                      # jit for both
                      traced = !isTRUE(model$turbo))        # CFM trace: standard only
     # Forward optional request knobs when present, so clients can drive the

--- a/R/tts.R
+++ b/R/tts.R
@@ -106,7 +106,7 @@ normalize_tts_text <- function(text, caps = TRUE, punctuation = TRUE) {
 chatterbox <- function(device = "cpu", turbo = FALSE, load = TRUE) {
     # Must run before the first CUDA op (cuda_is_available below): torch reads
     # its allocator GC rates once, at lazy CUDA init.
-    .set_cuda_gc_options(device)
+    .set_cuda_gc_options(device, turbo)
     # Fall back to CPU when the requested accelerator is absent
     # (Python from_pretrained does the same for MPS)
     if (grepl("^cuda", device) && !torch::cuda_is_available()) {
@@ -136,12 +136,13 @@ chatterbox <- function(device = "cpu", turbo = FALSE, load = TRUE) {
 # ahead of cuda_is_available(). The default reserved-rate floor (0.2) makes
 # torch gc on each allocation once a model occupies more than 20% of VRAM,
 # which dominated inference (53% of wall time was gc, the GPU work ~13%). The
-# floor scales with VRAM (smaller card, bigger footprint fraction, higher
-# floor): calibrated to two measured points for the ~4.1GB model, 16GB -> 0.26
-# and 6GB -> 0.75, linear in 1/VRAM. threshold_call_gc (host MB per forced gc)
-# is raised off its 4GB default too. Both respect an explicit user override.
-# See torch's memory-management vignette (torch.cuda_allocator_reserved_rate).
-.set_cuda_gc_options <- function(device) {
+# floor is the model's footprint as a fraction of VRAM: gc stays off until
+# reserved memory exceeds the model itself. Footprints (fp32) are 4.1GB
+# regular and 3.6GB turbo, so e.g. a 16GB card gives 0.26 / 0.22 and a 6GB
+# card gives 0.68 / 0.60. threshold_call_gc (host MB per forced gc) is raised
+# off its 4GB default too. Both respect an explicit user override. See torch's
+# memory-management vignette (torch.cuda_allocator_reserved_rate).
+.set_cuda_gc_options <- function(device, turbo = FALSE) {
     if (is.null(device) || !grepl("^cuda", device)) {
         return(invisible(NULL))
     }
@@ -163,11 +164,13 @@ chatterbox <- function(device = "cpu", turbo = FALSE, load = TRUE) {
     if (is.na(total_gb) || total_gb <= 0) {
         return(invisible(NULL))
     }
-    rate <- min(0.92, max(0.20, 4.704 / total_gb - 0.034))
+    footprint_gb <- if (isTRUE(turbo)) 3.6 else 4.1
+    rate <- min(0.92, max(0.20, footprint_gb / total_gb))
     options(torch.cuda_allocator_reserved_rate = rate)
     message(sprintf(
-        "chatterbox: torch.cuda_allocator_reserved_rate = %.2f, threshold_call_gc = %d MB (%.0f GB VRAM)",
-        rate, getOption("torch.threshold_call_gc"), total_gb))
+        "chatterbox: torch.cuda_allocator_reserved_rate = %.2f, threshold_call_gc = %d MB (%s model, %.0f GB VRAM)",
+        rate, getOption("torch.threshold_call_gc"),
+        if (isTRUE(turbo)) "turbo 3.6GB" else "regular 4.1GB", total_gb))
     invisible(rate)
 }
 

--- a/R/tts.R
+++ b/R/tts.R
@@ -138,7 +138,7 @@ chatterbox <- function(device = "cpu", turbo = FALSE, load = TRUE) {
 # which dominated inference (53% of wall time was gc, the GPU work ~13%). The
 # floor is the model's footprint as a fraction of VRAM: gc stays off until
 # reserved memory exceeds the model itself. Footprints (fp32) are 4.1GB
-# regular and 3.6GB turbo, so e.g. a 16GB card gives 0.26 / 0.22 and a 6GB
+# regular and 3.6GB turbo, so e.g. a 16GB card gives 0.26 / 0.23 and a 6GB
 # card gives 0.68 / 0.60. threshold_call_gc (host MB per forced gc) is raised
 # off its 4GB default too. Both respect an explicit user override. See torch's
 # memory-management vignette (torch.cuda_allocator_reserved_rate).

--- a/R/tts.R
+++ b/R/tts.R
@@ -104,6 +104,9 @@ normalize_tts_text <- function(text, caps = TRUE, punctuation = TRUE) {
 #' @return Chatterbox TTS model object, loaded unless \code{load = FALSE}
 #' @export
 chatterbox <- function(device = "cpu", turbo = FALSE, load = TRUE) {
+    # Must run before the first CUDA op (cuda_is_available below): torch reads
+    # its allocator GC rates once, at lazy CUDA init.
+    .set_cuda_gc_options(device)
     # Fall back to CPU when the requested accelerator is absent
     # (Python from_pretrained does the same for MPS)
     if (grepl("^cuda", device) && !torch::cuda_is_available()) {
@@ -125,6 +128,47 @@ chatterbox <- function(device = "cpu", turbo = FALSE, load = TRUE) {
         model <- load_chatterbox(model)
     }
     model
+}
+
+# Tune torch's CUDA garbage collection so it doesn't collect on nearly every
+# allocation. torch reads these rates ONCE, at lazy CUDA init (the first CUDA
+# op), so they must be set before then - this runs at the top of chatterbox(),
+# ahead of cuda_is_available(). The default reserved-rate floor (0.2) makes
+# torch gc on each allocation once a model occupies more than 20% of VRAM,
+# which dominated inference (53% of wall time was gc, the GPU work ~13%). The
+# floor scales with VRAM (smaller card, bigger footprint fraction, higher
+# floor): calibrated to two measured points for the ~4.1GB model, 16GB -> 0.26
+# and 6GB -> 0.75, linear in 1/VRAM. threshold_call_gc (host MB per forced gc)
+# is raised off its 4GB default too. Both respect an explicit user override.
+# See torch's memory-management vignette (torch.cuda_allocator_reserved_rate).
+.set_cuda_gc_options <- function(device) {
+    if (is.null(device) || !grepl("^cuda", device)) {
+        return(invisible(NULL))
+    }
+    if (is.null(getOption("torch.threshold_call_gc"))) {
+        options(torch.threshold_call_gc = 16000)
+    }
+    if (!is.null(getOption("torch.cuda_allocator_reserved_rate"))) {
+        return(invisible(NULL))
+    }
+    idx <- suppressWarnings(as.integer(sub("^cuda:?", "", device)))
+    if (length(idx) != 1L || is.na(idx)) {
+        idx <- 0L
+    }
+    total_gb <- tryCatch(
+        as.numeric(system2("nvidia-smi",
+            c("--query-gpu=memory.total", "--format=csv,noheader,nounits",
+              paste0("--id=", idx)), stdout = TRUE)[1]) / 1024,
+        error = function(e) NA_real_)
+    if (is.na(total_gb) || total_gb <= 0) {
+        return(invisible(NULL))
+    }
+    rate <- min(0.92, max(0.20, 4.704 / total_gb - 0.034))
+    options(torch.cuda_allocator_reserved_rate = rate)
+    message(sprintf(
+        "chatterbox: torch.cuda_allocator_reserved_rate = %.2f, threshold_call_gc = %d MB (%.0f GB VRAM)",
+        rate, getOption("torch.threshold_call_gc"), total_gb))
+    invisible(rate)
 }
 
 #' Load Chatterbox model weights

--- a/R/tts.R
+++ b/R/tts.R
@@ -119,9 +119,8 @@ chatterbox <- function(device = "cpu", turbo = FALSE, load = TRUE) {
     }
 
     model <- structure(
-                       list(device = device, turbo = turbo, t3 = NULL,
-                            s3gen = NULL, voice_encoder = NULL,
-                            tokenizer = NULL, loaded = FALSE),
+                       list(device = device, turbo = turbo, t3 = NULL, s3gen = NULL,
+                            voice_encoder = NULL, tokenizer = NULL, loaded = FALSE),
                        class = "chatterbox"
     )
     if (isTRUE(load)) {
@@ -157,20 +156,24 @@ chatterbox <- function(device = "cpu", turbo = FALSE, load = TRUE) {
         idx <- 0L
     }
     total_gb <- tryCatch(
-        as.numeric(system2("nvidia-smi",
-            c("--query-gpu=memory.total", "--format=csv,noheader,nounits",
-              paste0("--id=", idx)), stdout = TRUE)[1]) / 1024,
-        error = function(e) NA_real_)
+                         as.numeric(system2("nvidia-smi",
+                c("--query-gpu=memory.total", "--format=csv,noheader,nounits",
+                    paste0("--id=", idx)), stdout = TRUE)[1]) / 1024,
+                         error = function(e) NA_real_)
     if (is.na(total_gb) || total_gb <= 0) {
         return(invisible(NULL))
     }
-    footprint_gb <- if (isTRUE(turbo)) 3.6 else 4.1
+    if (isTRUE(turbo)) {
+        footprint_gb <- 3.6
+    } else {
+        footprint_gb <- 4.1
+    }
     rate <- min(0.92, max(0.20, footprint_gb / total_gb))
     options(torch.cuda_allocator_reserved_rate = rate)
     message(sprintf(
-        "chatterbox: torch.cuda_allocator_reserved_rate = %.2f, threshold_call_gc = %d MB (%s model, %.0f GB VRAM)",
-        rate, getOption("torch.threshold_call_gc"),
-        if (isTRUE(turbo)) "turbo 3.6GB" else "regular 4.1GB", total_gb))
+                    "chatterbox: torch.cuda_allocator_reserved_rate = %.2f, threshold_call_gc = %d MB (%s model, %.0f GB VRAM)",
+                    rate, getOption("torch.threshold_call_gc"),
+            if (isTRUE(turbo)) "turbo 3.6GB" else "regular 4.1GB", total_gb))
     invisible(rate)
 }
 
@@ -490,8 +493,7 @@ generate <- function(model, text, voice, exaggeration = 0.5,
                      backend = c("r", "jit"), top_k = 1000L,
                      repetition_penalty = 1.2, normalize_text = FALSE,
                      max_new_tokens = 1000L, max_cache_len = NULL,
-                     cfm_len = NULL, skip_vocoder = FALSE,
-                     output_path = NULL) {
+                     cfm_len = NULL, skip_vocoder = FALSE, output_path = NULL) {
     if (!is_loaded(model)) {
         stop("Model not loaded. Call load_chatterbox() first.")
     }
@@ -577,10 +579,10 @@ generate <- function(model, text, voice, exaggeration = 0.5,
     # bucket that way). Standard traced path only; turbo uses MeanFlow.
     if (!is_turbo && isTRUE(traced)) {
         options(chatterbox.cfm_len = if (!is.null(cfm_len)) {
-            as.integer(cfm_len)
-        } else {
-            640L + 2L * .token_bucket(n_tokens)
-        })
+                as.integer(cfm_len)
+            } else {
+                640L + 2L * .token_bucket(n_tokens)
+            })
     }
 
     if (use_autocast) {
@@ -679,7 +681,7 @@ generate <- function(model, text, voice, exaggeration = 0.5,
     }
 
     text_tokens <- torch::torch_tensor(text_ids,
-        dtype = torch::torch_long())$unsqueeze(1L)$to(device = device)
+                                       dtype = torch::torch_long())$unsqueeze(1L)$to(device = device)
 
     # Create T3 conditioning
     cond <- t3_cond(
@@ -766,9 +768,9 @@ generate <- function(model, text, voice, exaggeration = 0.5,
 #' @noRd
 .texts_to_speech_tokens <- function(model, texts, voice, normalize_text,
                                     use_autocast, exaggeration, cfg_weight,
-                                    temperature, top_p, min_p, traced, backend,
-                                    top_k, repetition_penalty, max_new_tokens,
-                                    max_cache_len) {
+                                    temperature, top_p, min_p, traced,
+                                    backend, top_k, repetition_penalty,
+                                    max_new_tokens, max_cache_len) {
     token_vecs <- vector("list", length(texts))
     eos <- logical(length(texts))
     for (i in seq_along(texts)) {
@@ -826,11 +828,11 @@ generate <- function(model, text, voice, exaggeration = 0.5,
         i <- live
         options(chatterbox.cfm_len = 640L + 2L * .token_bucket(lens[i]))
         st <- torch::torch_tensor(matrix(token_vecs[[i]], nrow = 1L),
-            dtype = torch::torch_long())$to(device = model$device)
+                                  dtype = torch::torch_long())$to(device = model$device)
         torch::with_no_grad({
             out <- model$s3gen$inference(speech_tokens = st,
-                                         ref_dict = voice$ref_dict,
-                                         finalize = TRUE, traced = TRUE)
+                ref_dict = voice$ref_dict,
+                finalize = TRUE, traced = TRUE)
         })
         results[[i]] <- mk_result(i, as.numeric(out[[1]]$squeeze()$cpu()))
         return(results)
@@ -856,7 +858,7 @@ generate <- function(model, text, voice, exaggeration = 0.5,
         i <- live[k]
         n_samples <- lens[i] * 2L * 480L
         results[[i]] <- mk_result(i,
-            as.numeric(wavs[k, 1:min(n_samples, wavs$size(2))]))
+                                  as.numeric(wavs[k, 1:min(n_samples, wavs$size(2))]))
     }
     results
 }
@@ -917,17 +919,17 @@ generate_batch <- function(model, texts, voice, ...) {
     }
 
     tk <- .texts_to_speech_tokens(model, texts, voice,
-        normalize_text = isTRUE(arg_or("normalize_text", FALSE)),
-        use_autocast = use_autocast,
-        exaggeration = arg_or("exaggeration", 0.5),
-        cfg_weight = arg_or("cfg_weight", 0.5),
-        temperature = arg_or("temperature", 0.8),
-        top_p = arg_or("top_p", 1.0), min_p = arg_or("min_p", 0.05),
-        traced = isTRUE(arg_or("traced", FALSE)),
-        backend = arg_or("backend", "r"), top_k = arg_or("top_k", 1000L),
-        repetition_penalty = arg_or("repetition_penalty", 1.2),
-        max_new_tokens = arg_or("max_new_tokens", 1000L),
-        max_cache_len = arg_or("max_cache_len", NULL))
+                                  normalize_text = isTRUE(arg_or("normalize_text", FALSE)),
+                                  use_autocast = use_autocast,
+                                  exaggeration = arg_or("exaggeration", 0.5),
+                                  cfg_weight = arg_or("cfg_weight", 0.5),
+                                  temperature = arg_or("temperature", 0.8),
+                                  top_p = arg_or("top_p", 1.0), min_p = arg_or("min_p", 0.05),
+                                  traced = isTRUE(arg_or("traced", FALSE)),
+                                  backend = arg_or("backend", "r"), top_k = arg_or("top_k", 1000L),
+                                  repetition_penalty = arg_or("repetition_penalty", 1.2),
+                                  max_new_tokens = arg_or("max_new_tokens", 1000L),
+                                  max_cache_len = arg_or("max_cache_len", NULL))
 
     # generate_batch is the throughput path: one eager batched S3Gen solve
     # (no traced single-utterance special case).
@@ -997,13 +999,16 @@ tts_to_file <- function(model, text, voice, output_path, ...) {
         return(.gpu_gb_cache[[device]])
     }
     idx <- sub("^cuda:?", "", device)
-    idx <- if (nzchar(idx)) suppressWarnings(as.integer(idx)) else 0L
+    if (nzchar(idx)) {
+        idx <- suppressWarnings(as.integer(idx))
+    } else {
+        idx <- 0L
+    }
     if (is.na(idx)) {
         idx <- 0L
     }
     out <- tryCatch(system2("nvidia-smi",
-                            c("--query-gpu=memory.total",
-                              "--format=csv,noheader,nounits",
+                            c("--query-gpu=memory.total", "--format=csv,noheader,nounits",
                               paste0("--id=", idx)),
                             stdout = TRUE, stderr = FALSE),
                     error = function(e) character(0))
@@ -1068,7 +1073,11 @@ tts_to_file <- function(model, text, voice, output_path, ...) {
                 out <- c(out, cur)
                 cur <- u
             } else {
-                cur <- if (nzchar(cur)) paste(cur, u) else u
+                if (nzchar(cur)) {
+                    cur <- paste(cur, u)
+                } else {
+                    cur <- u
+                }
             }
         }
         if (nzchar(cur)) {
@@ -1157,18 +1166,18 @@ tts_chunked <- function(model, text, voice, chunk_size = 200,
     # Run T3 on every chunk first, so batching and the memory cap use
     # ACTUAL speech-token lengths, not a char estimate (corteza review #2).
     tk <- .texts_to_speech_tokens(model, chunks, voice,
-        normalize_text = isTRUE(arg_or("normalize_text", FALSE)),
-        use_autocast = isTRUE(arg_or("autocast", FALSE)) &&
-            grepl("^cuda", model$device),
-        exaggeration = arg_or("exaggeration", 0.5),
-        cfg_weight = arg_or("cfg_weight", 0.5),
-        temperature = arg_or("temperature", 0.8),
-        top_p = arg_or("top_p", 1.0), min_p = arg_or("min_p", 0.05),
-        traced = traced, backend = arg_or("backend", "r"),
-        top_k = arg_or("top_k", 1000L),
-        repetition_penalty = arg_or("repetition_penalty", 1.2),
-        max_new_tokens = arg_or("max_new_tokens", 1000L),
-        max_cache_len = arg_or("max_cache_len", NULL))
+                                  normalize_text = isTRUE(arg_or("normalize_text", FALSE)),
+                                  use_autocast = isTRUE(arg_or("autocast", FALSE)) &&
+                                  grepl("^cuda", model$device),
+                                  exaggeration = arg_or("exaggeration", 0.5),
+                                  cfg_weight = arg_or("cfg_weight", 0.5),
+                                  temperature = arg_or("temperature", 0.8),
+                                  top_p = arg_or("top_p", 1.0), min_p = arg_or("min_p", 0.05),
+                                  traced = traced, backend = arg_or("backend", "r"),
+                                  top_k = arg_or("top_k", 1000L),
+                                  repetition_penalty = arg_or("repetition_penalty", 1.2),
+                                  max_new_tokens = arg_or("max_new_tokens", 1000L),
+                                  max_cache_len = arg_or("max_cache_len", NULL))
 
     # Bucket by actual token length, then synthesize within the per-card
     # cap, preserving original order. A group of one takes the traced
@@ -1181,7 +1190,7 @@ tts_chunked <- function(model, text, voice, chunk_size = 200,
         cap <- max(1L, max_batch %||% .cfm_max_batch(b, model$device))
         for (grp in split(idx, ceiling(seq_along(idx) / cap))) {
             res <- .s3gen_batch_from_tokens(model, tk$token_vecs[grp],
-                                            tk$eos[grp], voice, traced = traced)
+                tk$eos[grp], voice, traced = traced)
             for (j in seq_along(grp)) {
                 audio_chunks[[grp[j]]] <- res[[j]]$audio
             }
@@ -1267,5 +1276,9 @@ quick_tts <- function(text, reference_audio, output_path = NULL,
 
     res <- generate(model, text, reference_audio, autocast = autocast,
                     output_path = output_path)
-    if (is.null(output_path)) res else invisible(res)
+    if (is.null(output_path)) {
+        res
+    } else {
+        invisible(res)
+    }
 }

--- a/inst/tinytest/test_sniff_audio_format.R
+++ b/inst/tinytest/test_sniff_audio_format.R
@@ -1,0 +1,22 @@
+# .sniff_audio_format() detects the real container from magic bytes and
+# ignores the file extension: a WAV saved with a .mp3 name (which once ran
+# the MP3 decoder on PCM bytes and produced NaN garbage) must read as wav.
+
+wav <- system.file("audio", "jfk.wav", package = "chatterbox")
+mp3 <- system.file("audio", "jfk.mp3", package = "chatterbox")
+
+# Correctly-named files
+expect_equal(chatterbox:::.sniff_audio_format(wav), "wav")
+expect_equal(chatterbox:::.sniff_audio_format(mp3), "mp3")
+
+# Extension lies: WAV bytes under a .mp3 name still sniff as wav
+fake_mp3 <- tempfile(fileext = ".mp3")
+file.copy(wav, fake_mp3)
+expect_equal(chatterbox:::.sniff_audio_format(fake_mp3), "wav")
+unlink(fake_mp3)
+
+# ... and MP3 bytes under a .wav name still sniff as mp3
+fake_wav <- tempfile(fileext = ".wav")
+file.copy(mp3, fake_wav)
+expect_equal(chatterbox:::.sniff_audio_format(fake_wav), "mp3")
+unlink(fake_wav)


### PR DESCRIPTION
Three independent fixes found while wiring the native serve into a production TTS pipeline, plus version bumps (0.1.0.12 -> 0.1.0.15).

## serve: cache voice embeddings
The serve re-encoded the reference voice on every `/v1/audio/speech` request. Per-request re-encoding churns voice GPU tensors and races the CUDA caching allocator, intermittently producing NaN speaker conditioning — surfacing as a hard-to-trace `missing value where TRUE/FALSE needed` 500 and as degraded cloning. Reproduced at ~33-50% of requests on both an RTX 5060 Ti and a GTX 1660 Ti; 0 with the cache. Now caches each embedding by path+mtime; `trim_silence()` raises a clear error if NaN audio ever reaches it.

## read_audio: detect format by content, not extension
A reference saved as PCM/WAV but named `.mp3` ran the MP3 decoder on PCM bytes and produced NaN garbage (no error), so every clone from that voice came out as noise. Now sniffs the container from magic bytes (RIFF/WAVE, ID3, MP3 frame sync), falling back to the extension only when unrecognized.

## chatterbox(): tune CUDA GC rates before the first CUDA op
Profiling showed 53% of inference wall time was `<GC>` (GPU work ~13%). torch's allocator runs `gc()` on nearly every allocation once a model occupies more than 20% of VRAM (default `reserved_rate` floor 0.2). The rates are read once at lazy CUDA init, so `chatterbox()` sets them before the first CUDA op, respecting an explicit override. The floor is the model's footprint over VRAM (4.1GB regular, 3.6GB turbo): e.g. 16GB card -> 0.26 / 0.22, 6GB card -> 0.68 / 0.60; `threshold_call_gc` is raised to 16000 MB. Turbo ~2x faster on a 16GB card (10.7s -> 5.3s). See torch's memory-management vignette.