### PR TITLE
serve: fix named-voice lookup shadowed by working-directory entries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: chatterbox
 Title: Text-to-Speech Using the 'Chatterbox' Engine
-Version: 0.2.0
+Version: 0.2.0.1
 Date: 2026-06-21
 Authors@R:
     c(person("Troy", "Hernandez", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# chatterbox 0.2.0.1 (development)
+
+- `serve()` resolves a voice-library name (e.g. `"Barry"`) against
+  `voices_dir` before treating the `voice` field as a path. Previously a
+  like-named file or directory in the server's working directory shadowed
+  the library voice, so `/v1/audio/speech` returned a 500 ("cannot open
+  the connection"). A path is now accepted only when it is a regular file.
+
 # chatterbox 0.2.0
 
 First CRAN release. Gathers the 0.1.0.1 - 0.1.0.16 development series:

--- a/R/serve.R
+++ b/R/serve.R
@@ -321,21 +321,27 @@ serve <- function(port = 7810L, device = "cuda", voices_dir = NULL,
 }
 
 # Resolve a voice name (or path) to a reference audio file.
+#
+# A bare name (no path separator) is a voice-library name and is matched
+# against voices_dir FIRST, so a like-named file or directory in the
+# server's working directory cannot shadow it. Anything else is treated
+# as a path and accepted only if it is a regular file (not a directory).
 .serve_resolve_voice <- function(voice, voices_dir) {
-    if (file.exists(voice)) {
+    if (!grepl("[/\\\\]", voice)) {
+        files <- list.files(voices_dir, pattern = "\\.(wav|mp3|m4a|flac)$",
+                            full.names = TRUE, ignore.case = TRUE)
+        if (length(files) > 0L) {
+            names_no_ext <- tools::file_path_sans_ext(basename(files))
+            idx <- match(tolower(voice), tolower(names_no_ext))
+            if (!is.na(idx)) {
+                return(files[idx])
+            }
+        }
+    }
+    if (utils::file_test("-f", voice)) {
         return(voice)
     }
-    files <- list.files(voices_dir, pattern = "\\.(wav|mp3|m4a|flac)$",
-                        full.names = TRUE, ignore.case = TRUE)
-    if (length(files) == 0L) {
-        return(NULL)
-    }
-    names_no_ext <- tools::file_path_sans_ext(basename(files))
-    idx <- match(tolower(voice), tolower(names_no_ext))
-    if (is.na(idx)) {
-        return(NULL)
-    }
-    files[idx]
+    NULL
 }
 
 # List voice-library names.

--- a/inst/tinytest/test_serve_voice.R
+++ b/inst/tinytest/test_serve_voice.R
@@ -1,0 +1,35 @@
+# .serve_resolve_voice: library names must win over like-named entries in
+# the working directory, and only regular files count as path references.
+
+resolve <- chatterbox:::.serve_resolve_voice
+
+vd <- tempfile("voices_")
+dir.create(vd)
+barry <- file.path(vd, "Barry.mp3")
+writeLines("not really audio", barry)        # content irrelevant to resolution
+casey <- file.path(vd, "ShortCasey.wav")
+writeLines("x", casey)
+
+# Bare library name resolves to the library file.
+expect_equal(resolve("Barry", vd), barry)
+expect_equal(resolve("shortcasey", vd), casey) # case-insensitive
+
+# A directory named like the voice in the working dir must NOT shadow it.
+cwd <- tempfile("cwd_")
+dir.create(cwd)
+old <- setwd(cwd)
+on.exit(setwd(old), add = TRUE)
+dir.create("Barry")                            # the bug: file.exists("Barry") was TRUE
+expect_equal(resolve("Barry", vd), barry)      # still the library file, not "Barry"/
+setwd(old)
+
+# An explicit path to a regular file is returned as-is.
+expect_equal(resolve(barry, vd), barry)
+
+# A directory path is not a valid reference.
+expect_null(resolve(vd, vd))
+
+# Unknown name resolves to NULL.
+expect_null(resolve("Nonexistent", vd))
+
+unlink(vd, recursive = TRUE)


### PR DESCRIPTION
## Problem

`POST /v1/audio/speech` with a voice-library name (e.g. `{"voice":"Barry"}`)
returned `500 {"error":{"message":"cannot open the connection"}}`, even
though `GET /v1/audio/voices` lists the voice. A direct reference-audio
path worked fine.

Root cause: `.serve_resolve_voice()` ran `if (file.exists(voice)) return(voice)`
*before* checking the voice library. On the g5 serve host there is a
`Barry/` **directory** under the service's working directory, so
`file.exists("Barry")` was `TRUE` and the bare name `"Barry"` was returned
as if it were a path. `read_audio("Barry")` then tried to open a directory
and failed. Any voice whose name collides with a file/dir in the working
directory was unreachable.

## Fix

- A `voice` with no path separator is matched against `voices_dir` **first**,
  so working-directory entries can't shadow library voices.
- A `voice` is only accepted as a path when it is a **regular file**
  (`file_test("-f", ...)`), so a directory no longer counts.

Adds `inst/tinytest/test_serve_voice.R` reproducing the working-directory
shadow case (torch-free). Bumps to 0.2.0.1.

## Verification

New regression test passes (6/6). Reproduced the original failure on g5
(`read_audio` got the bare name `"Barry"` -> "cannot open the connection";
warning: "'Barry' ... is a directory"); the resolver now returns the
library file.