### PR TITLE
bench_resident: set TORCH_VERIFY_LOAD before loading torch

### DIFF
--- a/tools/bench_resident.R
+++ b/tools/bench_resident.R
@@ -11,6 +11,7 @@
 # the manifest's logical bytes; allocator numbers are printed as evidence
 # only. Allocator GC options are applied by the loaders themselves.
 
+Sys.setenv(TORCH_VERIFY_LOAD = "FALSE")
 suppressMessages({
     library(chatterbox)
     library(torch)


### PR DESCRIPTION
Without it the script dies at startup with `Lantern is not loaded` on any machine whose torch install cannot verify itself — the same guard whisper's bench script has. Fixed locally while benchmarking but missed the commit, so #25 landed without it.

Not shipped: `^tools$` is in `.Rbuildignore`.