### PR TITLE
CI: reject oversized tracked content

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,40 @@ env:
   TORCH_HOME: /tmp/torch
 
 jobs:
+  # Guard against a stray `git add -A <dir>` committing generated artifacts.
+  # The total is the load-bearing check: the 9.5 MB of .rds fixtures that once
+  # landed here were mostly well under any sane per-file cap.
+  size-guard:
+    runs-on: ubuntu-latest
+    env:
+      MAX_TOTAL_KB: 8192
+      MAX_FILE_KB: 2048
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Reject oversized tracked content
+        run: |
+          fail=0
+          total=$(git ls-files -z | xargs -0 -r du -bc | tail -1 | cut -f1)
+          total_kb=$((total / 1024))
+          echo "tracked total: ${total_kb} KB (cap ${MAX_TOTAL_KB} KB)"
+          if [ "$total_kb" -gt "$MAX_TOTAL_KB" ]; then
+            echo "::error::tracked content is ${total_kb} KB, over the ${MAX_TOTAL_KB} KB cap"
+            echo "largest tracked files:"
+            git ls-files -z | xargs -0 -r du -b | sort -rn | head -10 |
+              awk '{printf "  %8.1f KB  %s\n", $1/1024, $2}'
+            fail=1
+          fi
+          while IFS=$'\t' read -r sz path; do
+            kb=$((sz / 1024))
+            if [ "$kb" -gt "$MAX_FILE_KB" ]; then
+              echo "::error::${path} is ${kb} KB, over the ${MAX_FILE_KB} KB per-file cap"
+              fail=1
+            fi
+          done < <(git ls-files -z | xargs -0 -r du -b)
+          if [ "$fail" -eq 0 ]; then echo "size guard: OK"; fi
+          exit "$fail"
+
   ci:
     strategy:
       fail-fast: false


### PR DESCRIPTION
Mirrors the guard added to whisper. A `git add -A tools/` meant to stage one script committed 9.5 MB of generated `.rds` fixtures in #25 (undone in #27); the same slip put 32 MB into whisper.

**The total cap does the work here**: only 1 of those 13 fixtures exceeded 2 MB, so a per-file rule alone would have let the rest through.

- **8 MB total** (current tracked content: 2.2 MB)
- **2 MB per file** (largest legitimate file: `inst/audio/jfk.wav`, 1.4 MB)

Verified against the real commit:

```
ee4852b    tracked total: 11940 KB (cap 8192 KB) -> ::error::
main       tracked total:  2246 KB -> size guard: OK
```

Separate fast job; fails in seconds without waiting for R setup.