### PR TITLE
Port the tarball-content validator from subtitles

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,17 @@ jobs:
       - name: Dependencies
         run: ./run.sh install_all
 
+      # Needs R, so it lives here rather than in size-guard, which has no R
+      # setup. NOTE: CI checks out a clean tree, so this job can never see
+      # untracked scratch in a working tree -- that is what the mandatory
+      # LOCAL run of the same script catches (see CLAUDE.md). Runs on both
+      # matrix legs to exercise GNU/BSD portability rather than assume it.
+      - name: Validate tarball contents
+        run: bash tools/check_tarball.sh
+
+      - name: Validator self-test (negative cases)
+        run: bash tools/check_tarball_selftest.sh
+
       - name: Install torch
         run: |
           mkdir -p $TORCH_HOME

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -731,3 +731,26 @@ There is no `useDynLib` and no compiled code.
 - Alternative to tts.api container backend for local TTS (no Docker required)
 - Use `tts.api::tts(..., backend = "native")` for unified interface
 - pytorch-migration skill for migration patterns
+
+## Before submitting to CRAN
+
+Run this against the real working tree, every time:
+
+```bash
+bash tools/check_tarball.sh
+```
+
+`R CMD build` packages the working **directory**, not the git tree, and it
+skips only a fixed known set of dot-entries -- not arbitrary
+dot-directories. Any untracked scratch left in the package root ships. This
+has happened twice in sibling repos: a `git worktree add` left a full second
+copy of whisper inside whisper, and a temporary clone of an unrelated
+package in subtitles' root contributed 179 of 213 tarball entries.
+
+CI runs the same validator, but **CI cannot catch this class** -- it checks
+out a clean tree, so untracked local files do not exist there. The local run
+is the only thing that sees them. Inspect the final tarball by hand too:
+
+```bash
+tar tzf chatterbox_<version>.tar.gz | awk -F/ 'NF>1 {print $2}' | sort -u
+```

--- a/tools/check_tarball.sh
+++ b/tools/check_tarball.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Validate what R CMD build actually puts in the tarball.
+#
+# WHY THIS EXISTS, AND WHY IT MUST BE RUN LOCALLY
+#
+# R CMD build packages the working DIRECTORY, not the git tree. Anything
+# sitting in the package root that .Rbuildignore does not exclude ships --
+# including untracked scratch directories. R CMD build does NOT skip
+# arbitrary dot-directories; it excludes only a fixed known set (.git,
+# .Rhistory, ...), so a stray `.something/` is packaged in full.
+#
+# Two real incidents in this codebase:
+#   - a `git worktree add` left a complete second copy of the package at
+#     whisper/wtest_path/, which doubled that tarball
+#   - a temporary clone of an unrelated package at
+#     subtitles/.godotR-boot-review/ contributed 179 of 213 tarball entries
+#
+# Neither was tracked by git. A CI job checks out a clean tree, so CI can
+# never see either of them. **Only a local run against the real working
+# tree catches this class**, which is why this is a mandatory
+# pre-submission step and not merely a CI job.
+#
+# Portability: this is a mandatory local step, so it must run on whatever
+# machine is submitting. Kept to POSIX-ish tools -- no `stat -c` (GNU-only),
+# no `du -b` (GNU-only), and no parsing of `tar -tv` output, whose column
+# layout differs between GNU tar and bsdtar. Sizes come from `du -sk` on
+# extracted entries instead.
+#
+# Usage:
+#   tools/check_tarball.sh [package-dir]     # default: repo root
+#
+# Exit status 0 if the tarball contains only expected top-level entries.
+
+set -uo pipefail
+
+pkg_dir=${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}
+pkg_dir=$(cd "$pkg_dir" && pwd)
+
+# Exactly what chatterbox ships today. Deliberately tight rather than the
+# generic R-package set: if the package legitimately gains `vignettes` or
+# `src`, that is a real change and belongs in a commit that adds the entry
+# here. Anything unlisted is either that, or contamination.
+#
+# One per line, matched with `grep -Fqx`: fixed-string, whole-line. A
+# substring or regex match here fails OPEN -- an entry named `R.*` would
+# match `R` as a pattern and be waved through as expected content.
+allowed_list() {
+  cat <<'EOF'
+DESCRIPTION
+NAMESPACE
+NEWS.md
+LICENSE
+R
+man
+inst
+tests
+EOF
+}
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+echo "building from: $pkg_dir"
+if ! (cd "$work" && R CMD build "$pkg_dir" >build.log 2>&1); then
+  echo "::error::R CMD build failed"
+  tail -20 "$work/build.log"
+  exit 1
+fi
+
+tarball=$(ls "$work"/*.tar.gz 2>/dev/null | head -1)
+if [ -z "$tarball" ]; then
+  echo "::error::no tarball produced"
+  exit 1
+fi
+echo "tarball: $(basename "$tarball") ($(wc -c <"$tarball" | tr -d ' ') bytes)"
+
+# Extract and measure on disk: avoids `tar -tv` column-layout differences
+# between GNU tar and bsdtar, and gives portable sizes via `du -sk`.
+mkdir -p "$work/x"
+if ! tar xzf "$tarball" -C "$work/x"; then
+  echo "::error::could not extract tarball"
+  exit 1
+fi
+root=$(ls "$work/x" | head -1)
+pkg_root="$work/x/$root"
+
+# Three globs, because each misses what the others catch: `*` skips all
+# dotfiles, `.[!.]*` catches `.foo` but not `..foo`, and `..?*` catches
+# `..foo` without matching `.` or `..` themselves. A missed entry fails
+# OPEN. `-e || -L` so a dangling symlink is inspected rather than skipped
+# (`-e` follows the link and is false when the target is gone).
+fail=0
+count=0
+for path in "$pkg_root"/* "$pkg_root"/.[!.]* "$pkg_root"/..?*; do
+  [ -e "$path" ] || [ -L "$path" ] || continue
+  e=$(basename "$path")
+  count=$((count + 1))
+  if ! allowed_list | grep -Fqx -- "$e"; then
+    if [ -L "$path" ] && [ ! -e "$path" ]; then
+      echo "::error::unexpected top-level entry: ${e} (dangling symlink)"
+    else
+      kb=$(du -sk "$path" | awk '{print $1}')
+      echo "::error::unexpected top-level entry: ${e} (${kb} KB)"
+    fi
+    fail=1
+  fi
+done
+
+if [ "$fail" -eq 0 ]; then
+  echo "tarball contents: OK (${count} top-level entries)"
+else
+  echo
+  echo "R CMD build packages the working directory, not the git tree."
+  echo "Untracked scratch files in the package root ship unless"
+  echo ".Rbuildignore excludes them. Remove them, or add an exclusion."
+fi
+exit "$fail"

--- a/tools/check_tarball_selftest.sh
+++ b/tools/check_tarball_selftest.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Negative cases for check_tarball.sh.
+#
+# A validator that fails OPEN is worse than no validator: it converts
+# "nobody checked" into "someone checked and it was fine". Verifying only
+# the clean path proves nothing about that. Each case below is a bug that
+# was actually present and would have passed a contaminated tarball:
+#
+#   .scratch_test    the original incident (an untracked scratch directory)
+#   ..scratch_test   `.[!.]*` does not match names starting with two dots
+#   R.*              `grep -qw` treated the name as a regex, so this matched
+#                    the allowlist entry `R` and was waved through
+#   dangling symlink `[ -e ]` is false for one, so it was skipped entirely
+#
+# Each case is planted in a disposable copy of the package built from
+# `git archive`, never in the real working tree.
+#
+# Usage: tools/check_tarball_selftest.sh
+
+set -uo pipefail
+
+repo=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+validator="$repo/tools/check_tarball.sh"
+
+# The package copy lives in $work/pkg and the log in $work/out.log -- never
+# inside the copy. Writing the log into the package root contaminates the
+# fixture, and every negative case then "passes" because of the log rather
+# than the planted entry. (Observed while writing this.)
+fresh_copy() {
+  local work=$1
+  mkdir -p "$work/pkg"
+  git -C "$repo" archive HEAD | tar x -C "$work/pkg"
+}
+
+fail=0
+
+# Assert the validator rejects $1 AND that its output names $1 -- rejecting
+# for an unrelated reason would hide a fail-open bug.
+#
+# Two acceptable mechanisms. Usually the allowlist check flags the entry.
+# But a dangling symlink makes `R CMD build` itself fail ("cp: cannot
+# stat"), so the tarball is never produced; that is still fail-closed and
+# still names the file, so it counts. What must never happen is exit 0.
+expect_reject() {
+  local name=$1 work=$2 reason
+  if bash "$validator" "$work/pkg" >"$work/out.log" 2>&1; then
+    echo "::error::FAIL-OPEN: validator passed a tree containing '${name}'"
+    fail=1
+    return
+  fi
+  if grep -Fq "unexpected top-level entry: ${name}" "$work/out.log"; then
+    reason=$(grep -F "unexpected top-level entry: ${name}" "$work/out.log" |
+             head -1 | sed 's/.*(\(.*\))/(\1)/')
+  elif grep -Fq "R CMD build failed" "$work/out.log" &&
+       grep -Fq "$name" "$work/out.log"; then
+    reason="(R CMD build refused it)"
+  else
+    echo "::error::rejected '${name}' but nothing in the output names it:"
+    sed 's/^/    /' "$work/out.log" | head -6
+    fail=1
+    return
+  fi
+  printf 'ok  rejected  %-16s %s\n' "$name" "$reason"
+}
+
+plant_dir() {
+  local name=$1 work
+  work=$(mktemp -d)
+  fresh_copy "$work"
+  mkdir -p "$work/pkg/$name"
+  echo contamination >"$work/pkg/$name/payload"
+  expect_reject "$name" "$work"
+  rm -rf "$work"
+}
+
+plant_dangling_symlink() {
+  local work
+  work=$(mktemp -d)
+  fresh_copy "$work"
+  ln -s /nonexistent/target "$work/pkg/.dangling_test"
+  expect_reject ".dangling_test" "$work"
+  rm -rf "$work"
+}
+
+echo "== check_tarball.sh negative cases =="
+plant_dir ".scratch_test"
+plant_dir "..scratch_test"
+plant_dir "R.*"
+plant_dangling_symlink
+
+# And the positive case, so a validator that rejects everything is caught too.
+work=$(mktemp -d)
+fresh_copy "$work"
+if bash "$validator" "$work/pkg" >"$work/out.log" 2>&1; then
+  echo "ok  accepted  clean tree"
+else
+  echo "::error::validator rejected a clean tree"
+  cat "$work/out.log"
+  fail=1
+fi
+rm -rf "$work"
+
+if [ "$fail" -eq 0 ]; then
+  echo "self-test: OK"
+else
+  echo "self-test: FAILED"
+fi
+exit "$fail"


### PR DESCRIPTION
`R CMD build` packages the working **directory**, not the git tree, and skips only a fixed known set of dot-entries. Untracked scratch in the package root therefore ships.

This has bitten two sibling repos: a `git worktree add` left a full second copy of whisper inside whisper (823 KB vs 405 KB), and a temporary clone of an unrelated package in subtitles' root contributed **179 of 213 tarball entries**. Neither was tracked by git.

## Tight allowlist

Exactly the eight entries chatterbox ships today — note no `README.md`, which is build-ignored here. Gaining `vignettes` or `src` is a real change and belongs in a commit that adds the entry deliberately.

## Three layers, and only the third catches untracked contamination

| layer | catches |
|---|---|
| CI tracked-size cap | stray `git add -A <dir>` |
| CI tarball validator | unexpected content from tracked sources |
| **the same validator, run locally** | **untracked working-tree contamination** |

CI checks out a clean tree, so no CI job can see untracked local files. `CLAUDE.md` documents the local run as mandatory pre-submission, alongside a manual `tar tzf`.

## Failure behaviour is pinned, not assumed

`check_tarball_selftest.sh` plants `.scratch_test`, `..scratch_test`, `R.*`, and a dangling symlink into disposable `git archive` copies and asserts each is both rejected **and named**.

Verified locally: validator `OK (8 top-level entries)`, self-test `OK` on all five cases.