### PR TITLE
CI: use r-ci's RAPT backend, and exclude its run.sh from the build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -21,3 +21,6 @@
 ^vignettes$
 ^cran-comments\.md$
 ^tools$
+
+# r-ci writes this into the package root during CI setup
+^run\.sh$

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,8 +55,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # backend must be an action INPUT, not `env: BACKEND:` -- the action
+      # runs `export BACKEND=${{ inputs.backend }}` before calling run.sh, so a
+      # workflow-level env is silently overwritten and CI stays green while
+      # still using bspm. Confirm via "Selecting 'rapt'" in the Ubuntu log.
       - name: Setup
         uses: eddelbuettel/github-actions/r-ci@master
+        with:
+          backend: RAPT
 
       - name: Dependencies
         run: ./run.sh install_all


### PR DESCRIPTION
Two fixes found while releasing whisper 0.5.1.

## RAPT backend

The bspm bootstrap fetches from `r2u.stat.illinois.edu`, which timed out twice in one day and failed whisper's Ubuntu leg both times with `E: Unable to locate package r-cran-bspm`. r-ci already carries a rapt backend; selecting it is one input.

It must be the **input**, not `env: BACKEND: RAPT` — the action runs `export BACKEND=\${{ inputs.backend }}` before calling `run.sh`, so a workflow-level env is silently overwritten and CI passes while still using bspm. Verified on whisper by grepping the Ubuntu log for `Selecting 'rapt'` rather than trusting the green tick.

## run.sh exclusion

r-ci's Setup step writes `run.sh` (24 KB) into the package root, and `.Rbuildignore` did not exclude it — so a tarball built on a machine where r-ci had run would contain it.

whisper's tarball validator caught this on its first real CI run:

```
::error::unexpected top-level entry: run.sh (24 KB)
```

No submission was ever affected, because `run.sh` does not exist on the machine releases are built from — which is exactly why it went unnoticed for so long.