### PR TITLE
Stream chunks as they finish, and carry the spoken split with them

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: chatterbox
 Title: Text-to-Speech Using the 'Chatterbox' Engine
-Version: 0.2.1.1
+Version: 0.2.1.2
 Date: 2026-07-30
 Authors@R:
     c(person("Troy", "Hernandez", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,25 @@
+# chatterbox 0.2.1.2 (development)
+
+- `tts_chunked()` gains `on_chunk`, called as each chunk finishes so a
+  caller can start playing before the whole utterance is synthesized.
+  Always called in original chunk order: the batched path synthesizes
+  out of order, and streaming that to a player in completion order
+  would deliver the audio scrambled.
+
+- `tts_chunked()` gains `strategy` (`"auto"`, `"serial"`, `"batched"`).
+  Serial finishes one chunk at a time, so audio can start after chunk 1;
+  batched keeps the throughput. `"auto"` is what every existing caller
+  already gets. Asking for `"batched"` on turbo weights is an error
+  rather than a silent fall back to serial.
+
+- **The split comes back with the audio.** `on_chunk` receives the text
+  piece that chunk says, and the return gains `chunks` -- the same
+  pieces in spoken order, present whether or not a callback was
+  supplied. A caller reporting how much of a reply was actually heard
+  needs the split that was spoken; recovering it afterwards by
+  re-splitting the source cuts at the wrong boundary whenever the two
+  splits drift, and reads as a plausible sentence rather than an error.
+
 # chatterbox 0.2.1
 
 - `serve()` resolves a voice-library name (e.g. `"Barry"`) against

--- a/R/tts.R
+++ b/R/tts.R
@@ -1143,11 +1143,27 @@ tts_to_file <- function(model, text, voice, output_path, ...) {
 #
 # The watermark is the caller's, not this function's, so calling again with
 # nothing new added is silent rather than a replay of the prefix.
-.emit_ready <- function(audio_chunks, from, on_chunk, total) {
+#
+# `texts` is the split that produced this audio, carried alongside it so a
+# caller recording what was spoken indexes into the pieces that were
+# actually synthesized. Reconstructing them later by re-splitting the
+# source text is the failure this exists to prevent: a changed separator,
+# different whitespace, or slightly different model output shifts the
+# boundaries, and the result is a plausible-looking transcript cut in the
+# wrong place rather than an error.
+.emit_ready <- function(audio_chunks, from, on_chunk, total, texts) {
     i <- from
     n <- length(audio_chunks)
+    # Chunk i says text piece i. Everything downstream that reports how far
+    # playback got is only meaningful because of that, so a mismatch is a
+    # programming error and stops here -- where it is one line to find --
+    # rather than surfacing as speech attributed to the wrong sentence.
+    if (length(texts) != n) {
+        stop("texts and audio_chunks must be the same length (",
+             length(texts), " vs ", n, ")", call. = FALSE)
+    }
     while (i <= n && !is.null(audio_chunks[[i]])) {
-        on_chunk(audio_chunks[[i]], i, total)
+        on_chunk(audio_chunks[[i]], i, total, texts[[i]])
         i <- i + 1L
     }
     i
@@ -1216,12 +1232,19 @@ tts_to_file <- function(model, text, voice, output_path, ...) {
 #' @param chunk_size Maximum characters per chunk (default 200)
 #' @param max_batch Maximum chunks per batched solve. Default NULL: sized
 #'   per card from VRAM. Set an integer to override.
-#' @param on_chunk Optional function of \code{(audio, index, total)} called
-#'   as each chunk becomes available, so a caller can start playing before
-#'   the whole utterance is synthesized. \strong{Always called in original
-#'   chunk order.} The default \code{NULL} accumulates as before and the
-#'   return value is unchanged either way, so a caller that ignores this
+#' @param on_chunk Optional function of \code{(audio, index, total, text)}
+#'   called as each chunk becomes available, so a caller can start playing
+#'   before the whole utterance is synthesized. \strong{Always called in
+#'   original chunk order.} The default \code{NULL} accumulates as before and
+#'   the return value is unchanged either way, so a caller that ignores this
 #'   sees identical behaviour.
+#'
+#'   \code{text} is the piece this chunk says. It is handed over at emit
+#'   time rather than left to be recovered afterwards because a caller that
+#'   has to report what was heard needs the split that was actually spoken,
+#'   and because synthesis may be abandoned part-way -- on a barge-in, say --
+#'   in which case the return value never arrives and the emitted pieces are
+#'   the only record there is.
 #'
 #'   How much it actually streams depends on \code{strategy}:
 #'   \strong{serial streams, batched does not.} See there.
@@ -1249,7 +1272,11 @@ tts_to_file <- function(model, text, voice, output_path, ...) {
 #' @param ... Synthesis arguments forwarded to the T3 and S3Gen stages, as
 #'   in \code{\link{generate}} (exaggeration, cfg_weight, temperature,
 #'   backend, traced, normalize_text, max_new_tokens, ...)
-#' @return List with audio and sample_rate
+#' @return List with \code{audio}, \code{sample_rate}, and \code{chunks} --
+#'   the text pieces that were synthesized, in spoken order, one per chunk.
+#'   \code{chunks[[i]]} is what chunk \code{i} says, which is the mapping any
+#'   report of how far playback got depends on. Present whether or not
+#'   \code{on_chunk} was supplied.
 #' @examples
 #' \dontrun{
 #' model <- chatterbox("cuda")
@@ -1264,8 +1291,8 @@ tts_chunked <- function(model, text, voice, chunk_size = 200,
         stop("Model not loaded. Call load_chatterbox() first.")
     }
     if (!is.null(on_chunk) && !is.function(on_chunk)) {
-        stop("on_chunk must be a function of (audio, index, total), or NULL",
-             call. = FALSE)
+        stop("on_chunk must be a function of (audio, index, total, text), ",
+             "or NULL", call. = FALSE)
     }
     strategy <- match.arg(strategy)
     ## ONE COMBINATION IS IMPOSSIBLE, and it refuses rather than quietly
@@ -1285,7 +1312,11 @@ tts_chunked <- function(model, text, voice, chunk_size = 200,
 
     chunks <- .split_text_chunks(text, chunk_size)
     if (length(chunks) == 0L) {
-        return(list(audio = numeric(0), sample_rate = S3GEN_SR))
+        # `chunks` is character(0) rather than absent, so a caller reading
+        # res$chunks gets a vector on every path. One shape that is
+        # sometimes NULL is how a length() lands on the wrong branch.
+        return(list(audio = numeric(0), sample_rate = S3GEN_SR,
+                    chunks = character(0)))
     }
 
     # Resolve the voice once; re-encoding it per chunk is pure waste
@@ -1308,12 +1339,12 @@ tts_chunked <- function(model, text, voice, chunk_size = 200,
             message(sprintf("Processing chunk %d/%d", i, length(chunks)))
             audio_chunks[[i]] <- generate(model, chunks[i], voice, ...)$audio
             if (!is.null(on_chunk)) {
-                on_chunk(audio_chunks[[i]], i, length(chunks))
+                on_chunk(audio_chunks[[i]], i, length(chunks), chunks[[i]])
             }
             gc(verbose = FALSE)
         }
         return(list(audio = unlist(audio_chunks, use.names = FALSE),
-                    sample_rate = S3GEN_SR))
+                    sample_rate = S3GEN_SR, chunks = chunks))
     }
 
     # Run T3 on every chunk first, so batching and the memory cap use
@@ -1353,7 +1384,7 @@ tts_chunked <- function(model, text, voice, chunk_size = 200,
             }
             if (!is.null(on_chunk)) {
                 emitted <- .emit_ready(audio_chunks, emitted, on_chunk,
-                                       length(chunks))
+                                       length(chunks), chunks)
             }
             done <- done + length(grp)
             message(sprintf("Synthesized %d/%d chunks", done, length(chunks)))
@@ -1362,7 +1393,7 @@ tts_chunked <- function(model, text, voice, chunk_size = 200,
     }
 
     list(audio = unlist(audio_chunks, use.names = FALSE),
-         sample_rate = S3GEN_SR)
+         sample_rate = S3GEN_SR, chunks = chunks)
 }
 
 # ============================================================================

--- a/R/tts.R
+++ b/R/tts.R
@@ -1223,22 +1223,29 @@ tts_to_file <- function(model, text, voice, output_path, ...) {
 #'   return value is unchanged either way, so a caller that ignores this
 #'   sees identical behaviour.
 #'
-#'   How much it actually streams depends on which synthesis strategy runs,
-#'   and the difference is worth knowing before designing around it.
-#'   \strong{Serial synthesis streams; batched synthesis does not.} Serial
-#'   finishes one chunk at a time in order, so each is emitted the moment it
-#'   is done. Batched runs T3 over \emph{every} chunk before any S3Gen work
-#'   starts, then walks token-length buckets rather than text order -- so
-#'   nothing is emitted until T3 finishes across the whole input, and a
-#'   late-arriving early chunk holds back the ones behind it.
-#'
-#'   Today the strategy is not selectable: it follows the loaded model,
-#'   because the turbo weights have no batched implementation. So the turbo
-#'   model synthesizes serially and streams, and the standard model batches
-#'   and does not. That coupling is incidental rather than intended --
-#'   \code{\link{generate}} handles both models, so the standard weights
-#'   could synthesize serially too, trading throughput for time-to-first-
-#'   audio. Nothing exposes that choice yet.
+#'   How much it actually streams depends on \code{strategy}:
+#'   \strong{serial streams, batched does not.} See there.
+#' @param strategy Synthesis strategy.
+#'   \describe{
+#'     \item{\code{"auto"}}{(default) Batched where the weights support it,
+#'       serial where they do not. This is what every existing caller
+#'       already gets.}
+#'     \item{\code{"serial"}}{One chunk at a time in text order. Each is
+#'       finished when it is done, so \code{on_chunk} fires immediately and
+#'       audio can start playing after chunk 1. Costs throughput: one CFM
+#'       solve per chunk instead of one per batch. Works on both models.}
+#'     \item{\code{"batched"}}{Runs T3 over \emph{every} chunk, buckets them
+#'       by measured speech-token length, and synthesizes each bucket as one
+#'       padded S3Gen solve. Better throughput. Nothing can be emitted until
+#'       T3 finishes across the whole input, and buckets do not follow text
+#'       order, so \code{on_chunk} fires late and in held-back runs.
+#'       \strong{Standard weights only} -- there is no batched implementation
+#'       for turbo, and asking for it there is an error rather than a silent
+#'       fall back to serial.}
+#'   }
+#'   For a conversational turn, time-to-first-audio is the thing that
+#'   matters and throughput is nearly irrelevant, so \code{"serial"} is the
+#'   one to want. For synthesizing a long document, batched wins outright.
 #' @param ... Synthesis arguments forwarded to the T3 and S3Gen stages, as
 #'   in \code{\link{generate}} (exaggeration, cfg_weight, temperature,
 #'   backend, traced, normalize_text, max_new_tokens, ...)
@@ -1251,7 +1258,8 @@ tts_to_file <- function(model, text, voice, output_path, ...) {
 #' }
 #' @export
 tts_chunked <- function(model, text, voice, chunk_size = 200,
-                        max_batch = NULL, on_chunk = NULL, ...) {
+                        max_batch = NULL, on_chunk = NULL,
+                        strategy = c("auto", "serial", "batched"), ...) {
     if (!is_loaded(model)) {
         stop("Model not loaded. Call load_chatterbox() first.")
     }
@@ -1259,6 +1267,21 @@ tts_chunked <- function(model, text, voice, chunk_size = 200,
         stop("on_chunk must be a function of (audio, index, total), or NULL",
              call. = FALSE)
     }
+    strategy <- match.arg(strategy)
+    ## ONE COMBINATION IS IMPOSSIBLE, and it refuses rather than quietly
+    ## doing the other thing. The turbo weights have no batched synthesis
+    ## implementation, so a silent fall back to serial would hand the caller
+    ## a different throughput profile than it asked for and say nothing.
+    if (identical(strategy, "batched") && isTRUE(model$turbo)) {
+        stop("strategy = \"batched\" needs the standard weights; the turbo ",
+             "model has no batched synthesis path. Load with turbo = FALSE, ",
+             "or use strategy = \"serial\" or \"auto\".", call. = FALSE)
+    }
+    ## `auto` is capability negotiation rather than inference magic: batched
+    ## where the weights support it, serial where they do not. It is also
+    ## what every existing caller gets, so behaviour is unchanged.
+    serial <- identical(strategy, "serial") ||
+    (identical(strategy, "auto") && isTRUE(model$turbo))
 
     chunks <- .split_text_chunks(text, chunk_size)
     if (length(chunks) == 0L) {
@@ -1275,13 +1298,12 @@ tts_chunked <- function(model, text, voice, chunk_size = 200,
     traced <- isTRUE(arg_or("traced", FALSE))
     audio_chunks <- vector("list", length(chunks))
 
-    # The turbo weights have no batched synthesis implementation, so this
-    # path is serial. Serial is also the strategy that streams -- each chunk
-    # is finished and in text order, so it goes out immediately. The two
-    # facts are independent and only coincide here: `generate()` handles
-    # both models, so the standard weights could run this loop too and trade
-    # throughput for time-to-first-audio. Nothing selects that yet.
-    if (isTRUE(model$turbo)) {
+    # SERIAL: one chunk at a time, in text order, so each is finished and
+    # can go out immediately. `generate()` handles both models -- it branches
+    # on `is_turbo` internally -- so this loop is not turbo's private path.
+    # The turbo weights simply have no alternative; the standard weights
+    # reach it by asking, trading batched throughput for time-to-first-audio.
+    if (serial) {
         for (i in seq_along(chunks)) {
             message(sprintf("Processing chunk %d/%d", i, length(chunks)))
             audio_chunks[[i]] <- generate(model, chunks[i], voice, ...)$audio

--- a/R/tts.R
+++ b/R/tts.R
@@ -1128,6 +1128,31 @@ tts_to_file <- function(model, text, voice, output_path, ...) {
 #' @param chunk_size Target maximum chunk length in characters
 #' @return Character vector of chunks
 #' @noRd
+# Emit every chunk that is contiguous from `from`, in ORIGINAL order, and
+# return the new watermark.
+#
+# The batched path fills `audio_chunks` out of order: it walks token-length
+# buckets, so a short chunk late in the text can finish in the first group.
+# Streaming in completion order would deliver a player its audio scrambled,
+# which is worse than not streaming, so a chunk waits until everything ahead
+# of it exists.
+#
+# Worst case -- chunk 1 completes last -- this emits nothing until the end,
+# which is exactly the non-streaming behaviour it replaces. It never emits
+# less correctly, only less eagerly.
+#
+# The watermark is the caller's, not this function's, so calling again with
+# nothing new added is silent rather than a replay of the prefix.
+.emit_ready <- function(audio_chunks, from, on_chunk, total) {
+    i <- from
+    n <- length(audio_chunks)
+    while (i <= n && !is.null(audio_chunks[[i]])) {
+        on_chunk(audio_chunks[[i]], i, total)
+        i <- i + 1L
+    }
+    i
+}
+
 .split_text_chunks <- function(text, chunk_size = 200L) {
     # Greedily pack space-joined units into pieces of <= chunk_size chars.
     pack <- function(units) {
@@ -1191,6 +1216,20 @@ tts_to_file <- function(model, text, voice, output_path, ...) {
 #' @param chunk_size Maximum characters per chunk (default 200)
 #' @param max_batch Maximum chunks per batched solve. Default NULL: sized
 #'   per card from VRAM. Set an integer to override.
+#' @param on_chunk Optional function of \code{(audio, index, total)} called
+#'   as each chunk becomes available, so a caller can start playing before
+#'   the whole utterance is synthesized. \strong{Always called in original
+#'   chunk order.} The default \code{NULL} accumulates as before and the
+#'   return value is unchanged either way, so a caller that ignores this
+#'   sees identical behaviour.
+#'
+#'   How much it actually streams differs by path, and the difference is
+#'   worth knowing before designing around it. Turbo synthesizes serially,
+#'   so a chunk is emitted the moment it is done. The batched path runs T3
+#'   over \emph{every} chunk before any S3Gen work starts, and then walks
+#'   token-length buckets rather than original order -- so nothing is
+#'   emitted until T3 finishes, and a late-arriving early chunk holds back
+#'   the ones behind it. \strong{Turbo is the streaming-friendly path.}
 #' @param ... Synthesis arguments forwarded to the T3 and S3Gen stages, as
 #'   in \code{\link{generate}} (exaggeration, cfg_weight, temperature,
 #'   backend, traced, normalize_text, max_new_tokens, ...)
@@ -1203,9 +1242,13 @@ tts_to_file <- function(model, text, voice, output_path, ...) {
 #' }
 #' @export
 tts_chunked <- function(model, text, voice, chunk_size = 200,
-                        max_batch = NULL, ...) {
+                        max_batch = NULL, on_chunk = NULL, ...) {
     if (!is_loaded(model)) {
         stop("Model not loaded. Call load_chatterbox() first.")
+    }
+    if (!is.null(on_chunk) && !is.function(on_chunk)) {
+        stop("on_chunk must be a function of (audio, index, total), or NULL",
+             call. = FALSE)
     }
 
     chunks <- .split_text_chunks(text, chunk_size)
@@ -1223,11 +1266,16 @@ tts_chunked <- function(model, text, voice, chunk_size = 200,
     traced <- isTRUE(arg_or("traced", FALSE))
     audio_chunks <- vector("list", length(chunks))
 
-    # Turbo has no batched synthesis path: synthesize serially
+    # Turbo has no batched synthesis path: synthesize serially. Which also
+    # makes it the one path that streams properly -- each chunk is finished
+    # and in order, so it goes out immediately.
     if (isTRUE(model$turbo)) {
         for (i in seq_along(chunks)) {
             message(sprintf("Processing chunk %d/%d", i, length(chunks)))
             audio_chunks[[i]] <- generate(model, chunks[i], voice, ...)$audio
+            if (!is.null(on_chunk)) {
+                on_chunk(audio_chunks[[i]], i, length(chunks))
+            }
             gc(verbose = FALSE)
         }
         return(list(audio = unlist(audio_chunks, use.names = FALSE),
@@ -1256,6 +1304,10 @@ tts_chunked <- function(model, text, voice, chunk_size = 200,
     lens <- vapply(tk$token_vecs, length, integer(1L))
     buckets <- vapply(pmax(lens, 1L), .token_bucket, integer(1L))
     done <- 0L
+    ## How far the in-order stream has got. This walks buckets rather than
+    ## chunks, so a group can complete chunk 5 before chunk 1 exists --
+    ## emitting in completion order would hand a player its audio scrambled.
+    emitted <- 1L
     for (b in sort(unique(buckets))) {
         idx <- which(buckets == b)
         cap <- max(1L, max_batch %||% .cfm_max_batch(b, model$device))
@@ -1264,6 +1316,10 @@ tts_chunked <- function(model, text, voice, chunk_size = 200,
                 tk$eos[grp], voice, traced = traced)
             for (j in seq_along(grp)) {
                 audio_chunks[[grp[j]]] <- res[[j]]$audio
+            }
+            if (!is.null(on_chunk)) {
+                emitted <- .emit_ready(audio_chunks, emitted, on_chunk,
+                                       length(chunks))
             }
             done <- done + length(grp)
             message(sprintf("Synthesized %d/%d chunks", done, length(chunks)))

--- a/R/tts.R
+++ b/R/tts.R
@@ -1223,13 +1223,22 @@ tts_to_file <- function(model, text, voice, output_path, ...) {
 #'   return value is unchanged either way, so a caller that ignores this
 #'   sees identical behaviour.
 #'
-#'   How much it actually streams differs by path, and the difference is
-#'   worth knowing before designing around it. Turbo synthesizes serially,
-#'   so a chunk is emitted the moment it is done. The batched path runs T3
-#'   over \emph{every} chunk before any S3Gen work starts, and then walks
-#'   token-length buckets rather than original order -- so nothing is
-#'   emitted until T3 finishes, and a late-arriving early chunk holds back
-#'   the ones behind it. \strong{Turbo is the streaming-friendly path.}
+#'   How much it actually streams depends on which synthesis strategy runs,
+#'   and the difference is worth knowing before designing around it.
+#'   \strong{Serial synthesis streams; batched synthesis does not.} Serial
+#'   finishes one chunk at a time in order, so each is emitted the moment it
+#'   is done. Batched runs T3 over \emph{every} chunk before any S3Gen work
+#'   starts, then walks token-length buckets rather than text order -- so
+#'   nothing is emitted until T3 finishes across the whole input, and a
+#'   late-arriving early chunk holds back the ones behind it.
+#'
+#'   Today the strategy is not selectable: it follows the loaded model,
+#'   because the turbo weights have no batched implementation. So the turbo
+#'   model synthesizes serially and streams, and the standard model batches
+#'   and does not. That coupling is incidental rather than intended --
+#'   \code{\link{generate}} handles both models, so the standard weights
+#'   could synthesize serially too, trading throughput for time-to-first-
+#'   audio. Nothing exposes that choice yet.
 #' @param ... Synthesis arguments forwarded to the T3 and S3Gen stages, as
 #'   in \code{\link{generate}} (exaggeration, cfg_weight, temperature,
 #'   backend, traced, normalize_text, max_new_tokens, ...)
@@ -1266,9 +1275,12 @@ tts_chunked <- function(model, text, voice, chunk_size = 200,
     traced <- isTRUE(arg_or("traced", FALSE))
     audio_chunks <- vector("list", length(chunks))
 
-    # Turbo has no batched synthesis path: synthesize serially. Which also
-    # makes it the one path that streams properly -- each chunk is finished
-    # and in order, so it goes out immediately.
+    # The turbo weights have no batched synthesis implementation, so this
+    # path is serial. Serial is also the strategy that streams -- each chunk
+    # is finished and in text order, so it goes out immediately. The two
+    # facts are independent and only coincide here: `generate()` handles
+    # both models, so the standard weights could run this loop too and trade
+    # throughput for time-to-first-audio. Nothing selects that yet.
     if (isTRUE(model$turbo)) {
         for (i in seq_along(chunks)) {
             message(sprintf("Processing chunk %d/%d", i, length(chunks)))

--- a/inst/tinytest/test_emit_ready.R
+++ b/inst/tinytest/test_emit_ready.R
@@ -9,6 +9,9 @@
 # watermark is what remembers how far that has got. Worst case (the last
 # chunk completes last) this degenerates to emitting everything at the end,
 # which is exactly today's behaviour.
+#
+# Each emission also carries the text piece that chunk says, so a caller
+# recording what was spoken never has to re-derive the split.
 
 er <- chatterbox:::.emit_ready
 
@@ -16,38 +19,44 @@ er <- chatterbox:::.emit_ready
 # because what is under test is WHICH chunks arrive and in WHAT ORDER.
 rec <- function() {
     seen <- list()
-    list(fn = function(audio, index, total) {
+    list(fn = function(audio, index, total, text) {
              seen[[length(seen) + 1L]] <<- list(a = audio, i = index,
-                                                n = total)
+                                                n = total, t = text)
              invisible(NULL)
          },
          idx = function() vapply(seen, function(s) s$i, integer(1L)),
          aud = function() vapply(seen, function(s) s$a, numeric(1L)),
+         txt = function() vapply(seen, function(s) s$t, character(1L)),
          tot = function() vapply(seen, function(s) s$n, integer(1L)))
 }
 
+TX <- c("one", "two", "three")
+
 # ---- everything ready: emits all, in order, watermark past the end ----
 r <- rec()
-w <- er(list(1, 2, 3), 1L, r$fn, 3L)
+w <- er(list(1, 2, 3), 1L, r$fn, 3L, TX)
 expect_equal(r$idx(), 1:3)
 expect_equal(r$aud(), c(1, 2, 3))
 expect_equal(w, 4L)
 # `total` is the chunk count, not the emitted count -- a caller sizing a
 # progress bar off it would be wrong if this leaked the watermark instead.
 expect_equal(r$tot(), rep(3L, 3))
+# Chunk i says text piece i. Everything downstream that reports how far
+# playback got means nothing without this mapping.
+expect_equal(r$txt(), TX)
 
 # ---- a HOLE stops the flush ----
 # Position 2 is missing, so 3 must NOT be emitted even though it is ready.
 # This is the assertion the whole helper exists for: without it the batched
 # path streams chunk 3's audio before chunk 2's.
 r <- rec()
-w <- er(list(1, NULL, 3), 1L, r$fn, 3L)
+w <- er(list(1, NULL, 3), 1L, r$fn, 3L, TX)
 expect_equal(r$idx(), 1L)
 expect_equal(w, 2L)
 
 # ---- nothing ready: no calls, watermark unmoved ----
 r <- rec()
-w <- er(list(NULL, NULL), 1L, r$fn, 2L)
+w <- er(list(NULL, NULL), 1L, r$fn, 2L, TX[1:2])
 expect_equal(length(r$idx()), 0L)
 expect_equal(w, 1L)
 
@@ -59,17 +68,17 @@ r <- rec()
 w <- 1L
 
 buf[[3]] <- 30                      # bucket with the long chunk finishes first
-w <- er(buf, w, r$fn, 3L)
+w <- er(buf, w, r$fn, 3L, TX)
 expect_equal(length(r$idx()), 0L)   # 3 is ready and still must not go out
 expect_equal(w, 1L)
 
 buf[[1]] <- 10
-w <- er(buf, w, r$fn, 3L)
+w <- er(buf, w, r$fn, 3L, TX)
 expect_equal(r$idx(), 1L)
 expect_equal(w, 2L)
 
 buf[[2]] <- 20
-w <- er(buf, w, r$fn, 3L)
+w <- er(buf, w, r$fn, 3L, TX)
 expect_equal(r$idx(), c(1L, 2L, 3L))
 expect_equal(r$aud(), c(10, 20, 30))
 expect_equal(w, 4L)
@@ -80,15 +89,32 @@ expect_equal(w, 4L)
 # 3, 1, 2 -- which is the bug this replaces.
 expect_true(!is.unsorted(r$idx()))
 
+# TEXT FOLLOWS THE INDEX, NOT THE CALL. This flush resumed from watermark 2
+# and emitted two chunks, so anything reading `texts` relative to where the
+# flush started -- texts[[i - from + 1]], the natural-looking slip -- hands
+# out "one", "two" for chunks 2 and 3. Both orders are three plausible
+# sentences in the right sequence; only the absolute index is correct.
+expect_equal(r$txt(), TX)
+
 # ---- resuming from a watermark does not re-emit ----
 # Called again with nothing new, it must stay silent rather than replay the
 # prefix. A re-emitting flush would duplicate audio on every group boundary.
 r2 <- rec()
-w2 <- er(buf, w, r2$fn, 3L)
+w2 <- er(buf, w, r2$fn, 3L, TX)
 expect_equal(length(r2$idx()), 0L)
 expect_equal(w2, 4L)
 
 # ---- a zero-length buffer is not an error ----
 r <- rec()
-expect_equal(er(list(), 1L, r$fn, 0L), 1L)
+expect_equal(er(list(), 1L, r$fn, 0L, character(0)), 1L)
 expect_equal(length(r$idx()), 0L)
+
+# ---- 1:1 is checked, not assumed ----
+# A split that has drifted from the audio it labels is a programming error,
+# and it stops here rather than emitting speech attributed to the wrong
+# sentence. Checked before any emission: a partial flush followed by an
+# error is the worst of both.
+r <- rec()
+expect_error(er(list(1, 2, 3), 1L, r$fn, 3L, TX[1:2]), "same length")
+expect_equal(length(r$idx()), 0L)
+expect_error(er(list(1, 2), 1L, r$fn, 2L, TX), "same length")

--- a/inst/tinytest/test_emit_ready.R
+++ b/inst/tinytest/test_emit_ready.R
@@ -1,0 +1,94 @@
+# .emit_ready: the in-order flush behind tts_chunked's on_chunk callback.
+#
+# The batched (non-turbo) path synthesizes OUT OF ORDER -- it buckets chunks
+# by speech-token length and walks `sort(unique(buckets))`, so chunk 5 can
+# finish before chunk 1. Streaming that to a player in completion order would
+# produce audio in the wrong order, which is worse than not streaming at all.
+#
+# So a chunk is emitted only once every chunk before it is done, and the
+# watermark is what remembers how far that has got. Worst case (the last
+# chunk completes last) this degenerates to emitting everything at the end,
+# which is exactly today's behaviour.
+
+er <- chatterbox:::.emit_ready
+
+# A recorder standing in for the caller. It records rather than plays,
+# because what is under test is WHICH chunks arrive and in WHAT ORDER.
+rec <- function() {
+    seen <- list()
+    list(fn = function(audio, index, total) {
+             seen[[length(seen) + 1L]] <<- list(a = audio, i = index,
+                                                n = total)
+             invisible(NULL)
+         },
+         idx = function() vapply(seen, function(s) s$i, integer(1L)),
+         aud = function() vapply(seen, function(s) s$a, numeric(1L)),
+         tot = function() vapply(seen, function(s) s$n, integer(1L)))
+}
+
+# ---- everything ready: emits all, in order, watermark past the end ----
+r <- rec()
+w <- er(list(1, 2, 3), 1L, r$fn, 3L)
+expect_equal(r$idx(), 1:3)
+expect_equal(r$aud(), c(1, 2, 3))
+expect_equal(w, 4L)
+# `total` is the chunk count, not the emitted count -- a caller sizing a
+# progress bar off it would be wrong if this leaked the watermark instead.
+expect_equal(r$tot(), rep(3L, 3))
+
+# ---- a HOLE stops the flush ----
+# Position 2 is missing, so 3 must NOT be emitted even though it is ready.
+# This is the assertion the whole helper exists for: without it the batched
+# path streams chunk 3's audio before chunk 2's.
+r <- rec()
+w <- er(list(1, NULL, 3), 1L, r$fn, 3L)
+expect_equal(r$idx(), 1L)
+expect_equal(w, 2L)
+
+# ---- nothing ready: no calls, watermark unmoved ----
+r <- rec()
+w <- er(list(NULL, NULL), 1L, r$fn, 2L)
+expect_equal(length(r$idx()), 0L)
+expect_equal(w, 1L)
+
+# ---- the out-of-order fill, which is the real batched sequence ----
+# Bucketing completes 3, then 1, then 2. Nothing may be emitted until 1
+# lands, and when 2 lands it must carry 3 with it.
+buf <- vector("list", 3L)
+r <- rec()
+w <- 1L
+
+buf[[3]] <- 30                      # bucket with the long chunk finishes first
+w <- er(buf, w, r$fn, 3L)
+expect_equal(length(r$idx()), 0L)   # 3 is ready and still must not go out
+expect_equal(w, 1L)
+
+buf[[1]] <- 10
+w <- er(buf, w, r$fn, 3L)
+expect_equal(r$idx(), 1L)
+expect_equal(w, 2L)
+
+buf[[2]] <- 20
+w <- er(buf, w, r$fn, 3L)
+expect_equal(r$idx(), c(1L, 2L, 3L))
+expect_equal(r$aud(), c(10, 20, 30))
+expect_equal(w, 4L)
+
+# ---- ORDER IS THE CONTRACT, and this is the assertion that pins it ----
+# Emitted order must equal original index order, not completion order. A
+# test that only counted emissions would pass on a helper that streamed
+# 3, 1, 2 -- which is the bug this replaces.
+expect_true(!is.unsorted(r$idx()))
+
+# ---- resuming from a watermark does not re-emit ----
+# Called again with nothing new, it must stay silent rather than replay the
+# prefix. A re-emitting flush would duplicate audio on every group boundary.
+r2 <- rec()
+w2 <- er(buf, w, r2$fn, 3L)
+expect_equal(length(r2$idx()), 0L)
+expect_equal(w2, 4L)
+
+# ---- a zero-length buffer is not an error ----
+r <- rec()
+expect_equal(er(list(), 1L, r$fn, 0L), 1L)
+expect_equal(length(r$idx()), 0L)

--- a/inst/tinytest/test_spoken_split.R
+++ b/inst/tinytest/test_spoken_split.R
@@ -1,0 +1,119 @@
+# The split that was actually spoken, carried out of tts_chunked.
+#
+# `heardThrough`-style reporting -- a player saying how many chunks reached
+# the speaker before it was cut -- is only meaningful because chunk i says
+# text piece i. If the piece is recovered afterwards by re-splitting the
+# source, any drift (a changed separator, different whitespace, slightly
+# different model output) moves the boundaries, and the transcript is cut
+# in the wrong place while still reading as a plausible sentence. So the
+# split leaves with the audio rather than being reconstructible from it.
+#
+# No GPU here: `generate` is stubbed, which is the only thing between this
+# and the real serial path. Everything else -- the split, the loop, the
+# emission, the return -- is the shipping code.
+
+library(chatterbox)
+
+fake <- function(turbo = FALSE) structure(list(loaded = TRUE, turbo = turbo),
+                                          class = "chatterbox")
+
+# A non-character voice, so create_voice_embedding is never reached. The
+# stub ignores it; what matters is that it is not a path to resolve.
+VOICE <- list(embedding = 1)
+
+ns <- asNamespace("chatterbox")
+with_generate <- function(stub, expr) {
+    orig <- get("generate", envir = ns, inherits = FALSE)
+    assignInNamespace("generate", stub, ns = "chatterbox")
+    on.exit(assignInNamespace("generate", orig, ns = "chatterbox"), add = TRUE)
+    force(expr)
+}
+
+# One sample of audio per chunk, valued by the chunk's length, so a
+# mis-paired emission is visible in the audio as well as the text.
+stub_gen <- function(model, text, voice, ...) {
+    list(audio = as.numeric(nchar(text)), sample_rate = 24000L)
+}
+
+TEXT <- "First sentence here. Second one follows. And a third to finish."
+
+# ---- the emitted text is the piece that chunk says ---------------------
+local({
+    seen <- list()
+    res <- with_generate(stub_gen,
+        suppressMessages(tts_chunked(fake(), TEXT, VOICE, chunk_size = 25L,
+            strategy = "serial",
+            on_chunk = function(audio, index, total, text) {
+                seen[[length(seen) + 1L]] <<- list(i = index, n = total,
+                                                   t = text, a = audio)
+            })))
+
+    expect_true(length(seen) > 1L)
+    idx <- vapply(seen, function(s) s$i, integer(1L))
+    txt <- vapply(seen, function(s) s$t, character(1L))
+
+    # Emitted in order, one per chunk, and `total` is the chunk count.
+    expect_equal(idx, seq_along(res$chunks))
+    expect_true(all(vapply(seen, function(s) s$n, integer(1L)) ==
+                    length(res$chunks)))
+
+    # THE MAPPING. What arrived at the callback is exactly what came back
+    # in the return -- so a caller that recorded pieces as they played and
+    # a caller that read them at the end agree. Asserted against res$chunks
+    # rather than against a hand-written expected split: a literal here
+    # would only ever agree with itself, and would need editing every time
+    # the splitter's boundaries move for an unrelated reason.
+    expect_equal(txt, res$chunks)
+
+    # And the audio was generated FROM that piece, not merely delivered
+    # next to it -- an emission that paired chunk i's audio with piece j
+    # passes a text-only check.
+    expect_equal(vapply(seen, function(s) s$a, numeric(1L)),
+                 as.numeric(nchar(res$chunks)))
+})
+
+# ---- the split comes back whether or not anyone was listening ----------
+# A caller that synthesizes the whole utterance and reads the split at the
+# end must get the same thing, or "what was spoken" depends on whether
+# someone happened to pass a callback.
+local({
+    quiet <- with_generate(stub_gen,
+        suppressMessages(tts_chunked(fake(), TEXT, VOICE, chunk_size = 25L,
+                                     strategy = "serial")))
+    loud <- with_generate(stub_gen,
+        suppressMessages(tts_chunked(fake(), TEXT, VOICE, chunk_size = 25L,
+            strategy = "serial", on_chunk = function(a, i, n, t) NULL)))
+    expect_equal(quiet$chunks, loud$chunks)
+    expect_equal(quiet$audio, loud$audio)
+})
+
+# ---- rejoining the pieces covers the input -----------------------------
+# The split is a partition of what was said, not a summary of it. Without
+# this, a splitter that dropped a clause would still satisfy every
+# index-mapping assertion above.
+local({
+    res <- with_generate(stub_gen,
+        suppressMessages(tts_chunked(fake(), TEXT, VOICE, chunk_size = 25L,
+                                     strategy = "serial")))
+    expect_equal(gsub("[ ]+", " ", paste(res$chunks, collapse = " ")),
+                 gsub("[ ]+", " ", TEXT))
+})
+
+# ---- empty input still answers with a vector ---------------------------
+# character(0), not NULL. One shape that is sometimes absent is how a
+# length() check lands on the wrong branch. This path returns before the
+# model is touched, so no stub is needed.
+local({
+    res <- tts_chunked(fake(), "   ", VOICE)
+    expect_true("chunks" %in% names(res))
+    expect_equal(res$chunks, character(0))
+    expect_equal(length(res$audio), 0L)
+})
+
+# ---- the arity is named in the refusal ---------------------------------
+# A caller passing a three-argument callback gets "unused argument" from R
+# with no clue which argument or whose contract. The guard's message is
+# the only place the shape is stated at the call site.
+e <- tryCatch(tts_chunked(fake(), "hi", VOICE, on_chunk = 42),
+              error = conditionMessage)
+expect_true(grepl("text", e))

--- a/inst/tinytest/test_strategy_guard.R
+++ b/inst/tinytest/test_strategy_guard.R
@@ -32,9 +32,12 @@ expect_true(grepl("serial", err))
 # Each must get past the strategy guard. They then fail later for want of a
 # real model, which is the proof they were not stopped here: a guard that
 # rejected everything would pass an "it errored" test.
+# The warning is `create_voice_embedding` failing to open "v", which is the
+# EVIDENCE the call got past the guard and kept going. Expected, so it is
+# silenced here rather than left to bury a warning that is not expected.
 past_guard <- function(...) {
-    e <- tryCatch(tts_chunked(..., text = "hi", voice = "v"),
-                  error = conditionMessage)
+    e <- suppressWarnings(tryCatch(tts_chunked(..., text = "hi", voice = "v"),
+                                   error = conditionMessage))
     !grepl("no batched", e)
 }
 expect_true(past_guard(fake(TRUE), strategy = "serial"))

--- a/inst/tinytest/test_strategy_guard.R
+++ b/inst/tinytest/test_strategy_guard.R
@@ -1,0 +1,58 @@
+# tts_chunked's strategy argument, at the point where it decides.
+#
+# No GPU: every assertion here is about a refusal or an argument check, all
+# of which happen before the model is touched. What each strategy actually
+# SYNTHESIZES is a live question and belongs to a live arm.
+#
+# The model stands in only for the two fields the guard reads -- `loaded`
+# and `turbo`. That is the guard's whole contract, so a fixture carrying
+# exactly those is testing the thing rather than a shape handed to it.
+
+library(chatterbox)
+
+fake <- function(turbo) structure(list(loaded = TRUE, turbo = turbo),
+                                  class = "chatterbox")
+
+# ---- batched on turbo is REFUSED, not silently downgraded ---------------
+#
+# The turbo weights have no batched implementation. Falling back to serial
+# would hand the caller a different throughput profile than it asked for
+# and say nothing -- and "asked for batched, got serial" is invisible from
+# the return value, which is identical either way.
+err <- tryCatch(tts_chunked(fake(TRUE), "hi", "v", strategy = "batched"),
+                error = conditionMessage)
+expect_true(is.character(err))
+expect_true(grepl("turbo", err))
+expect_true(grepl("no batched", err))
+# It must name a way out, not just refuse.
+expect_true(grepl("serial", err))
+
+# ---- the other three combinations are NOT refused -----------------------
+#
+# Each must get past the strategy guard. They then fail later for want of a
+# real model, which is the proof they were not stopped here: a guard that
+# rejected everything would pass an "it errored" test.
+past_guard <- function(...) {
+    e <- tryCatch(tts_chunked(..., text = "hi", voice = "v"),
+                  error = conditionMessage)
+    !grepl("no batched", e)
+}
+expect_true(past_guard(fake(TRUE), strategy = "serial"))
+expect_true(past_guard(fake(TRUE), strategy = "auto"))
+expect_true(past_guard(fake(FALSE), strategy = "batched"))
+expect_true(past_guard(fake(FALSE), strategy = "serial"))
+expect_true(past_guard(fake(FALSE), strategy = "auto"))
+
+# ---- an unknown strategy is refused by match.arg ------------------------
+expect_error(tts_chunked(fake(FALSE), "hi", "v", strategy = "fastest"))
+
+# ---- on_chunk must be a function ---------------------------------------
+e <- tryCatch(tts_chunked(fake(FALSE), "hi", "v", on_chunk = 42),
+              error = conditionMessage)
+expect_true(grepl("on_chunk", e))
+
+# ---- the default is unchanged behaviour --------------------------------
+# Existing callers pass no strategy and must keep getting "auto". If this
+# default ever moves, every current caller silently changes throughput
+# profile.
+expect_equal(eval(formals(tts_chunked)$strategy)[1], "auto")

--- a/man/cam_dense_tdnn_block.Rd
+++ b/man/cam_dense_tdnn_block.Rd
@@ -3,8 +3,14 @@
 \alias{cam_dense_tdnn_block}
 \title{CAM Dense TDNN Block (multiple layers with dense connections)}
 \usage{
-cam_dense_tdnn_block(num_layers, in_channels, out_channels, bn_channels,
-                     kernel_size, dilation = 1)
+cam_dense_tdnn_block(
+  num_layers,
+  in_channels,
+  out_channels,
+  bn_channels,
+  kernel_size,
+  dilation = 1
+)
 }
 \arguments{
 \item{num_layers}{Number of layers}

--- a/man/cam_dense_tdnn_layer.Rd
+++ b/man/cam_dense_tdnn_layer.Rd
@@ -3,8 +3,13 @@
 \alias{cam_dense_tdnn_layer}
 \title{CAM Dense TDNN Layer}
 \usage{
-cam_dense_tdnn_layer(in_channels, out_channels, bn_channels, kernel_size,
-                     dilation = 1)
+cam_dense_tdnn_layer(
+  in_channels,
+  out_channels,
+  bn_channels,
+  kernel_size,
+  dilation = 1
+)
 }
 \arguments{
 \item{in_channels}{Input channels}

--- a/man/cam_layer.Rd
+++ b/man/cam_layer.Rd
@@ -3,8 +3,15 @@
 \alias{cam_layer}
 \title{CAM (Context-Aware Masking) Layer}
 \usage{
-cam_layer(bn_channels, out_channels, kernel_size, stride = 1, padding = 0,
-          dilation = 1, reduction = 2)
+cam_layer(
+  bn_channels,
+  out_channels,
+  kernel_size,
+  stride = 1,
+  padding = 0,
+  dilation = 1,
+  reduction = 2
+)
 }
 \arguments{
 \item{bn_channels}{Bottleneck channels}

--- a/man/campplus.Rd
+++ b/man/campplus.Rd
@@ -3,8 +3,12 @@
 \alias{campplus}
 \title{CAMPPlus speaker encoder}
 \usage{
-campplus(feat_dim = 80, embedding_size = 192, growth_rate = 32,
-         init_channels = 128)
+campplus(
+  feat_dim = 80,
+  embedding_size = 192,
+  growth_rate = 32,
+  init_channels = 128
+)
 }
 \arguments{
 \item{feat_dim}{Input feature dimension (default 80)}

--- a/man/causal_cfm.Rd
+++ b/man/causal_cfm.Rd
@@ -3,8 +3,12 @@
 \alias{causal_cfm}
 \title{Causal Conditional Flow Matching}
 \usage{
-causal_cfm(in_channels = 320, out_channels = 80, spk_emb_dim = 80,
-           meanflow = FALSE)
+causal_cfm(
+  in_channels = 320,
+  out_channels = 80,
+  spk_emb_dim = 80,
+  meanflow = FALSE
+)
 }
 \arguments{
 \item{in_channels}{Input channels (x + mu + spks + cond)}

--- a/man/causal_conv1d.Rd
+++ b/man/causal_conv1d.Rd
@@ -3,7 +3,13 @@
 \alias{causal_conv1d}
 \title{Causal Conv1d - pads left only}
 \usage{
-causal_conv1d(in_channels, out_channels, kernel_size, stride = 1L, dilation = 1L)
+causal_conv1d(
+  in_channels,
+  out_channels,
+  kernel_size,
+  stride = 1L,
+  dilation = 1L
+)
 }
 \arguments{
 \item{in_channels}{Input channels}

--- a/man/causal_masked_diff_xvec.Rd
+++ b/man/causal_masked_diff_xvec.Rd
@@ -3,9 +3,15 @@
 \alias{causal_masked_diff_xvec}
 \title{Causal Masked Diff with Xvector}
 \usage{
-causal_masked_diff_xvec(vocab_size = 6561, input_size = 512, output_size = 80,
-                        spk_embed_dim = 192, input_frame_rate = 25,
-                        token_mel_ratio = 2, meanflow = FALSE)
+causal_masked_diff_xvec(
+  vocab_size = 6561,
+  input_size = 512,
+  output_size = 80,
+  spk_embed_dim = 192,
+  input_frame_rate = 25,
+  token_mel_ratio = 2,
+  meanflow = FALSE
+)
 }
 \arguments{
 \item{vocab_size}{Speech token vocabulary size}

--- a/man/cfm_estimator.Rd
+++ b/man/cfm_estimator.Rd
@@ -3,9 +3,14 @@
 \alias{cfm_estimator}
 \title{CFM Estimator (ConditionalDecoder)}
 \usage{
-cfm_estimator(in_channels = 320L, out_channels = 80L, hidden_dim = 256L,
-              num_mid_blocks = 12L, num_transformer_blocks = 4L,
-              meanflow = FALSE)
+cfm_estimator(
+  in_channels = 320L,
+  out_channels = 80L,
+  hidden_dim = 256L,
+  num_mid_blocks = 12L,
+  num_transformer_blocks = 4L,
+  meanflow = FALSE
+)
 }
 \arguments{
 \item{in_channels}{Input channels (default 320 = x + mu + spks + cond)}

--- a/man/chatterbox.Rd
+++ b/man/chatterbox.Rd
@@ -32,7 +32,7 @@ the not-loaded error paths), then load later with
 When \code{tune_gc = TRUE} (the default) and \code{device} is CUDA, this
 raises torch's allocator GC floors before the first CUDA op. torch otherwise
 runs \code{gc()} on nearly every allocation once a model occupies more than
-20\\% of VRAM, which dominates inference. It sets session-global
+20\% of VRAM, which dominates inference. It sets session-global
 \code{torch.cuda_allocator_reserved_rate} (the model footprint over VRAM) and
 \code{torch.threshold_call_gc}, only when they are unset, so an explicit
 setting always wins. This is a deliberate, persistent side effect (torch

--- a/man/compute_mel_spectrogram.Rd
+++ b/man/compute_mel_spectrogram.Rd
@@ -3,9 +3,17 @@
 \alias{compute_mel_spectrogram}
 \title{Compute mel spectrogram (S3Gen compatible)}
 \usage{
-compute_mel_spectrogram(y, n_fft = 1920, n_mels = 80, sr = 24000,
-                        hop_size = 480, win_size = 1920, fmin = 0, fmax = 8000,
-                        center = FALSE)
+compute_mel_spectrogram(
+  y,
+  n_fft = 1920,
+  n_mels = 80,
+  sr = 24000,
+  hop_size = 480,
+  win_size = 1920,
+  fmin = 0,
+  fmax = 8000,
+  center = FALSE
+)
 }
 \arguments{
 \item{y}{Audio samples as torch tensor or numeric vector}

--- a/man/compute_rope_frequencies.Rd
+++ b/man/compute_rope_frequencies.Rd
@@ -3,8 +3,13 @@
 \alias{compute_rope_frequencies}
 \title{Compute rotary position embeddings frequencies}
 \usage{
-compute_rope_frequencies(dim, max_seq_len, theta = 5e+05, scaling = NULL,
-                         device = "cpu")
+compute_rope_frequencies(
+  dim,
+  max_seq_len,
+  theta = 5e+05,
+  scaling = NULL,
+  device = "cpu"
+)
 }
 \arguments{
 \item{dim}{Dimension of embeddings}

--- a/man/conformer_encoder_layer.Rd
+++ b/man/conformer_encoder_layer.Rd
@@ -3,8 +3,12 @@
 \alias{conformer_encoder_layer}
 \title{Conformer Encoder Layer}
 \usage{
-conformer_encoder_layer(n_feat = 512, n_head = 8, n_ffn = 2048,
-                        dropout_rate = 0.1)
+conformer_encoder_layer(
+  n_feat = 512,
+  n_head = 8,
+  n_ffn = 2048,
+  dropout_rate = 0.1
+)
 }
 \arguments{
 \item{n_feat}{Feature dimension}

--- a/man/create_mel_filterbank.Rd
+++ b/man/create_mel_filterbank.Rd
@@ -3,8 +3,15 @@
 \alias{create_mel_filterbank}
 \title{Create mel filterbank}
 \usage{
-create_mel_filterbank(sr, n_fft, n_mels, fmin = 0, fmax = NULL,
-                      norm = "slaney", htk = FALSE)
+create_mel_filterbank(
+  sr,
+  n_fft,
+  n_mels,
+  fmin = 0,
+  fmax = NULL,
+  norm = "slaney",
+  htk = FALSE
+)
 }
 \arguments{
 \item{sr}{Sample rate}

--- a/man/create_voice_embedding.Rd
+++ b/man/create_voice_embedding.Rd
@@ -3,8 +3,13 @@
 \alias{create_voice_embedding}
 \title{Create voice embedding from reference audio}
 \usage{
-create_voice_embedding(model, audio, sample_rate = NULL, autocast = NULL,
-                       norm_loudness = NULL)
+create_voice_embedding(
+  model,
+  audio,
+  sample_rate = NULL,
+  autocast = NULL,
+  norm_loudness = NULL
+)
 }
 \arguments{
 \item{model}{Chatterbox model}

--- a/man/dot-turbo_sample_token.Rd
+++ b/man/dot-turbo_sample_token.Rd
@@ -3,8 +3,14 @@
 \alias{.turbo_sample_token}
 \title{Sample a token using turbo logit processors}
 \usage{
-.turbo_sample_token(logits, generated_ids, temperature, top_k, top_p,
-                    repetition_penalty)
+.turbo_sample_token(
+  logits,
+  generated_ids,
+  temperature,
+  top_k,
+  top_p,
+  repetition_penalty
+)
 }
 \arguments{
 \item{logits}{(B, vocab_size) logits}

--- a/man/espnet_rel_positional_encoding.Rd
+++ b/man/espnet_rel_positional_encoding.Rd
@@ -3,7 +3,11 @@
 \alias{espnet_rel_positional_encoding}
 \title{Sinusoidal positional encoding (Espnet RelPositionalEncoding)}
 \usage{
-espnet_rel_positional_encoding(d_model = 512, dropout_rate = 0.1, max_len = 5000)
+espnet_rel_positional_encoding(
+  d_model = 512,
+  dropout_rate = 0.1,
+  max_len = 5000
+)
 }
 \arguments{
 \item{d_model}{Model dimension}

--- a/man/generate.Rd
+++ b/man/generate.Rd
@@ -3,12 +3,27 @@
 \alias{generate}
 \title{Generate speech from text}
 \usage{
-generate(model, text, voice, exaggeration = 0.5, cfg_weight = 0.5,
-         temperature = 0.8, top_p = 1, min_p = 0.05, autocast = NULL,
-         traced = FALSE, backend = c("r", "jit"), top_k = 1000L,
-         repetition_penalty = 1.2, normalize_text = FALSE,
-         max_new_tokens = 1000L, max_cache_len = NULL, cfm_len = NULL,
-         skip_vocoder = FALSE, output_path = NULL)
+generate(
+  model,
+  text,
+  voice,
+  exaggeration = 0.5,
+  cfg_weight = 0.5,
+  temperature = 0.8,
+  top_p = 1,
+  min_p = 0.05,
+  autocast = NULL,
+  traced = FALSE,
+  backend = c("r", "jit"),
+  top_k = 1000L,
+  repetition_penalty = 1.2,
+  normalize_text = FALSE,
+  max_new_tokens = 1000L,
+  max_cache_len = NULL,
+  cfm_len = NULL,
+  skip_vocoder = FALSE,
+  output_path = NULL
+)
 }
 \arguments{
 \item{model}{Chatterbox model}
@@ -42,7 +57,7 @@ milliseconds, via \code{torch::jit_compile}): with tuned GC
 settings (see \code{\link{chatterbox_gc_options}}) it is the
 fastest native path (~11 ms/token long-form), auto-sizes its KV
 cache so generation always completes, and ships no compiled code.
-It replaced an equivalent C++ backend (within ~20\\% of its speed)
+It replaced an equivalent C++ backend (within ~20\% of its speed)
 that required linking against torch's private libraries.}
 
 \item{top_k}{Integer. Top-k sampling parameter (turbo model only).

--- a/man/hift_generator.Rd
+++ b/man/hift_generator.Rd
@@ -3,15 +3,25 @@
 \alias{hift_generator}
 \title{HiFTNet Generator}
 \usage{
-hift_generator(in_channels = 80, base_channels = 512, nb_harmonics = 8,
-               sampling_rate = 22050, nsf_alpha = 0.1, nsf_sigma = 0.003,
-               nsf_voiced_threshold = 10, upsample_rates = c(8, 8),
-               upsample_kernel_sizes = c(16, 16), istft_n_fft = 16,
-               istft_hop_len = 4, resblock_kernel_sizes = c(3, 7, 11),
-               resblock_dilation_sizes = list(c(1, 3, 5), c(1, 3, 5), c(1, 3, 5)),
-               source_resblock_kernel_sizes = c(7, 11),
-               source_resblock_dilation_sizes = list(c(1, 3, 5), c(1, 3, 5)),
-               lrelu_slope = 0.1, audio_limit = 0.99)
+hift_generator(
+  in_channels = 80,
+  base_channels = 512,
+  nb_harmonics = 8,
+  sampling_rate = 22050,
+  nsf_alpha = 0.1,
+  nsf_sigma = 0.003,
+  nsf_voiced_threshold = 10,
+  upsample_rates = c(8, 8),
+  upsample_kernel_sizes = c(16, 16),
+  istft_n_fft = 16,
+  istft_hop_len = 4,
+  resblock_kernel_sizes = c(3, 7, 11),
+  resblock_dilation_sizes = list(c(1, 3, 5), c(1, 3, 5), c(1, 3, 5)),
+  source_resblock_kernel_sizes = c(7, 11),
+  source_resblock_dilation_sizes = list(c(1, 3, 5), c(1, 3, 5)),
+  lrelu_slope = 0.1,
+  audio_limit = 0.99
+)
 }
 \arguments{
 \item{in_channels}{Input mel channels}

--- a/man/quick_tts.Rd
+++ b/man/quick_tts.Rd
@@ -3,8 +3,14 @@
 \alias{quick_tts}
 \title{Quick TTS - one-line text-to-speech}
 \usage{
-quick_tts(text, reference_audio, output_path = NULL, device = "cpu",
-          autocast = NULL, turbo = FALSE)
+quick_tts(
+  text,
+  reference_audio,
+  output_path = NULL,
+  device = "cpu",
+  autocast = NULL,
+  turbo = FALSE
+)
 }
 \arguments{
 \item{text}{Text to synthesize}

--- a/man/s3_tokenizer_config.Rd
+++ b/man/s3_tokenizer_config.Rd
@@ -3,8 +3,13 @@
 \alias{s3_tokenizer_config}
 \title{S3Tokenizer model configuration}
 \usage{
-s3_tokenizer_config(n_mels = 128, n_audio_state = 1280, n_audio_head = 20,
-                    n_audio_layer = 6, n_codebook_size = 6561)
+s3_tokenizer_config(
+  n_mels = 128,
+  n_audio_state = 1280,
+  n_audio_head = 20,
+  n_audio_layer = 6,
+  n_codebook_size = 6561
+)
 }
 \arguments{
 \item{n_mels}{Number of mel bins (default 128)}

--- a/man/serve.Rd
+++ b/man/serve.Rd
@@ -3,8 +3,15 @@
 \alias{serve}
 \title{Serve chatterbox over HTTP}
 \usage{
-serve(port = 7810L, device = "cuda", voices_dir = NULL, turbo = FALSE,
-      timeout = 300L, max_body = 10L * 1024L^2, warmup = TRUE)
+serve(
+  port = 7810L,
+  device = "cuda",
+  voices_dir = NULL,
+  turbo = FALSE,
+  timeout = 300L,
+  max_body = 10L * 1024L^2,
+  warmup = TRUE
+)
 }
 \arguments{
 \item{port}{Integer. TCP port to listen on. Default 7810.}

--- a/man/sine_gen.Rd
+++ b/man/sine_gen.Rd
@@ -3,8 +3,13 @@
 \alias{sine_gen}
 \title{Sine Generator}
 \usage{
-sine_gen(sample_rate, harmonic_num = 0, sine_amp = 0.1, noise_std = 0.003,
-         voiced_threshold = 0)
+sine_gen(
+  sample_rate,
+  harmonic_num = 0,
+  sine_amp = 0.1,
+  noise_std = 0.003,
+  voiced_threshold = 0
+)
 }
 \arguments{
 \item{sample_rate}{Sampling rate in Hz}

--- a/man/source_module_hn_nsf.Rd
+++ b/man/source_module_hn_nsf.Rd
@@ -3,8 +3,14 @@
 \alias{source_module_hn_nsf}
 \title{Source Module for Neural Source Filter}
 \usage{
-source_module_hn_nsf(sample_rate, upsample_scale, harmonic_num = 0,
-                     sine_amp = 0.1, add_noise_std = 0.003, voiced_threshold = 0)
+source_module_hn_nsf(
+  sample_rate,
+  upsample_scale,
+  harmonic_num = 0,
+  sine_amp = 0.1,
+  add_noise_std = 0.003,
+  voiced_threshold = 0
+)
 }
 \arguments{
 \item{sample_rate}{Sampling rate}

--- a/man/t3_cond.Rd
+++ b/man/t3_cond.Rd
@@ -3,8 +3,12 @@
 \alias{t3_cond}
 \title{Create T3 conditioning object}
 \usage{
-t3_cond(speaker_emb, cond_prompt_speech_tokens = NULL,
-        cond_prompt_speech_emb = NULL, emotion_adv = 0.5)
+t3_cond(
+  speaker_emb,
+  cond_prompt_speech_tokens = NULL,
+  cond_prompt_speech_emb = NULL,
+  emotion_adv = 0.5
+)
 }
 \arguments{
 \item{speaker_emb}{Speaker embedding tensor (B, 256)}

--- a/man/t3_inference.Rd
+++ b/man/t3_inference.Rd
@@ -3,9 +3,17 @@
 \alias{t3_inference}
 \title{Run T3 inference to generate speech tokens}
 \usage{
-t3_inference(model, cond, text_tokens, max_new_tokens = 1000,
-             temperature = 0.8, cfg_weight = 0.5, top_p = 1, min_p = 0.05,
-             repetition_penalty = 1.2)
+t3_inference(
+  model,
+  cond,
+  text_tokens,
+  max_new_tokens = 1000,
+  temperature = 0.8,
+  cfg_weight = 0.5,
+  top_p = 1,
+  min_p = 0.05,
+  repetition_penalty = 1.2
+)
 }
 \arguments{
 \item{model}{T3 model}

--- a/man/t3_inference_jit.Rd
+++ b/man/t3_inference_jit.Rd
@@ -3,9 +3,18 @@
 \alias{t3_inference_jit}
 \title{T3 inference with a TorchScript decode loop}
 \usage{
-t3_inference_jit(model, cond, text_tokens, max_new_tokens = 1000,
-                 temperature = 0.8, cfg_weight = 0.5, top_p = 1, min_p = 0.05,
-                 repetition_penalty = 1.2, max_cache_len = NULL)
+t3_inference_jit(
+  model,
+  cond,
+  text_tokens,
+  max_new_tokens = 1000,
+  temperature = 0.8,
+  cfg_weight = 0.5,
+  top_p = 1,
+  min_p = 0.05,
+  repetition_penalty = 1.2,
+  max_cache_len = NULL
+)
 }
 \arguments{
 \item{model}{T3 model}

--- a/man/t3_inference_traced.Rd
+++ b/man/t3_inference_traced.Rd
@@ -3,9 +3,18 @@
 \alias{t3_inference_traced}
 \title{T3 inference with JIT tracing (optimized)}
 \usage{
-t3_inference_traced(model, cond, text_tokens, max_new_tokens = 1000,
-                    temperature = 0.8, cfg_weight = 0.5, top_p = 1,
-                    min_p = 0.05, repetition_penalty = 1.2, max_cache_len = 350L)
+t3_inference_traced(
+  model,
+  cond,
+  text_tokens,
+  max_new_tokens = 1000,
+  temperature = 0.8,
+  cfg_weight = 0.5,
+  top_p = 1,
+  min_p = 0.05,
+  repetition_penalty = 1.2,
+  max_cache_len = 350L
+)
 }
 \arguments{
 \item{model}{T3 model}

--- a/man/t3_inference_turbo.Rd
+++ b/man/t3_inference_turbo.Rd
@@ -3,9 +3,16 @@
 \alias{t3_inference_turbo}
 \title{Run T3 turbo inference to generate speech tokens}
 \usage{
-t3_inference_turbo(model, cond, text_tokens, max_new_tokens = 1000,
-                   temperature = 0.8, top_k = 1000L, top_p = 0.95,
-                   repetition_penalty = 1.2)
+t3_inference_turbo(
+  model,
+  cond,
+  text_tokens,
+  max_new_tokens = 1000,
+  temperature = 0.8,
+  top_k = 1000L,
+  top_p = 0.95,
+  repetition_penalty = 1.2
+)
 }
 \arguments{
 \item{model}{T3 turbo model}

--- a/man/t3_inference_turbo_jit.Rd
+++ b/man/t3_inference_turbo_jit.Rd
@@ -3,9 +3,17 @@
 \alias{t3_inference_turbo_jit}
 \title{Turbo T3 inference with a TorchScript decode loop}
 \usage{
-t3_inference_turbo_jit(model, cond, text_tokens, max_new_tokens = 1000,
-                       temperature = 0.8, top_k = 1000L, top_p = 0.95,
-                       repetition_penalty = 1.2, max_cache_len = NULL)
+t3_inference_turbo_jit(
+  model,
+  cond,
+  text_tokens,
+  max_new_tokens = 1000,
+  temperature = 0.8,
+  top_k = 1000L,
+  top_p = 0.95,
+  repetition_penalty = 1.2,
+  max_cache_len = NULL
+)
 }
 \arguments{
 \item{model}{T3 turbo model}

--- a/man/tdnn_layer.Rd
+++ b/man/tdnn_layer.Rd
@@ -3,8 +3,14 @@
 \alias{tdnn_layer}
 \title{TDNN Layer}
 \usage{
-tdnn_layer(in_channels, out_channels, kernel_size, stride = 1, dilation = 1,
-           padding = NULL)
+tdnn_layer(
+  in_channels,
+  out_channels,
+  kernel_size,
+  stride = 1,
+  dilation = 1,
+  padding = NULL
+)
 }
 \arguments{
 \item{in_channels}{Input channels}

--- a/man/tts_chunked.Rd
+++ b/man/tts_chunked.Rd
@@ -3,7 +3,15 @@
 \alias{tts_chunked}
 \title{Generate speech for long text (the long-form policy layer)}
 \usage{
-tts_chunked(model, text, voice, chunk_size = 200, max_batch = NULL, ...)
+tts_chunked(
+  model,
+  text,
+  voice,
+  chunk_size = 200,
+  max_batch = NULL,
+  on_chunk = NULL,
+  ...
+)
 }
 \arguments{
 \item{model}{Chatterbox model}
@@ -16,6 +24,21 @@ tts_chunked(model, text, voice, chunk_size = 200, max_batch = NULL, ...)
 
 \item{max_batch}{Maximum chunks per batched solve. Default NULL: sized
 per card from VRAM. Set an integer to override.}
+
+\item{on_chunk}{Optional function of \code{(audio, index, total)} called
+as each chunk becomes available, so a caller can start playing before
+the whole utterance is synthesized. \strong{Always called in original
+chunk order.} The default \code{NULL} accumulates as before and the
+return value is unchanged either way, so a caller that ignores this
+sees identical behaviour.
+
+How much it actually streams differs by path, and the difference is
+worth knowing before designing around it. Turbo synthesizes serially,
+so a chunk is emitted the moment it is done. The batched path runs T3
+over \emph{every} chunk before any S3Gen work starts, and then walks
+token-length buckets rather than original order -- so nothing is
+emitted until T3 finishes, and a late-arriving early chunk holds back
+the ones behind it. \strong{Turbo is the streaming-friendly path.}}
 
 \item{...}{Synthesis arguments forwarded to the T3 and S3Gen stages, as
 in \code{\link{generate}} (exaggeration, cfg_weight, temperature,

--- a/man/tts_chunked.Rd
+++ b/man/tts_chunked.Rd
@@ -32,13 +32,22 @@ chunk order.} The default \code{NULL} accumulates as before and the
 return value is unchanged either way, so a caller that ignores this
 sees identical behaviour.
 
-How much it actually streams differs by path, and the difference is
-worth knowing before designing around it. Turbo synthesizes serially,
-so a chunk is emitted the moment it is done. The batched path runs T3
-over \emph{every} chunk before any S3Gen work starts, and then walks
-token-length buckets rather than original order -- so nothing is
-emitted until T3 finishes, and a late-arriving early chunk holds back
-the ones behind it. \strong{Turbo is the streaming-friendly path.}}
+How much it actually streams depends on which synthesis strategy runs,
+and the difference is worth knowing before designing around it.
+\strong{Serial synthesis streams; batched synthesis does not.} Serial
+finishes one chunk at a time in order, so each is emitted the moment it
+is done. Batched runs T3 over \emph{every} chunk before any S3Gen work
+starts, then walks token-length buckets rather than text order -- so
+nothing is emitted until T3 finishes across the whole input, and a
+late-arriving early chunk holds back the ones behind it.
+
+Today the strategy is not selectable: it follows the loaded model,
+because the turbo weights have no batched implementation. So the turbo
+model synthesizes serially and streams, and the standard model batches
+and does not. That coupling is incidental rather than intended --
+\code{\link{generate}} handles both models, so the standard weights
+could synthesize serially too, trading throughput for time-to-first-
+audio. Nothing exposes that choice yet.}
 
 \item{...}{Synthesis arguments forwarded to the T3 and S3Gen stages, as
 in \code{\link{generate}} (exaggeration, cfg_weight, temperature,

--- a/man/tts_chunked.Rd
+++ b/man/tts_chunked.Rd
@@ -26,12 +26,19 @@ tts_chunked(
 \item{max_batch}{Maximum chunks per batched solve. Default NULL: sized
 per card from VRAM. Set an integer to override.}
 
-\item{on_chunk}{Optional function of \code{(audio, index, total)} called
-as each chunk becomes available, so a caller can start playing before
-the whole utterance is synthesized. \strong{Always called in original
-chunk order.} The default \code{NULL} accumulates as before and the
-return value is unchanged either way, so a caller that ignores this
+\item{on_chunk}{Optional function of \code{(audio, index, total, text)}
+called as each chunk becomes available, so a caller can start playing
+before the whole utterance is synthesized. \strong{Always called in
+original chunk order.} The default \code{NULL} accumulates as before and
+the return value is unchanged either way, so a caller that ignores this
 sees identical behaviour.
+
+\code{text} is the piece this chunk says. It is handed over at emit
+time rather than left to be recovered afterwards because a caller that
+has to report what was heard needs the split that was actually spoken,
+and because synthesis may be abandoned part-way -- on a barge-in, say --
+in which case the return value never arrives and the emitted pieces are
+the only record there is.
 
 How much it actually streams depends on \code{strategy}:
 \strong{serial streams, batched does not.} See there.}
@@ -63,7 +70,11 @@ in \code{\link{generate}} (exaggeration, cfg_weight, temperature,
 backend, traced, normalize_text, max_new_tokens, ...)}
 }
 \value{
-List with audio and sample_rate
+List with \code{audio}, \code{sample_rate}, and \code{chunks} --
+  the text pieces that were synthesized, in spoken order, one per chunk.
+  \code{chunks[[i]]} is what chunk \code{i} says, which is the mapping any
+  report of how far playback got depends on. Present whether or not
+  \code{on_chunk} was supplied.
 }
 \description{
 Splits at sentence boundaries (oversized sentences subdivided at commas,

--- a/man/tts_chunked.Rd
+++ b/man/tts_chunked.Rd
@@ -10,6 +10,7 @@ tts_chunked(
   chunk_size = 200,
   max_batch = NULL,
   on_chunk = NULL,
+  strategy = c("auto", "serial", "batched"),
   ...
 )
 }
@@ -32,22 +33,30 @@ chunk order.} The default \code{NULL} accumulates as before and the
 return value is unchanged either way, so a caller that ignores this
 sees identical behaviour.
 
-How much it actually streams depends on which synthesis strategy runs,
-and the difference is worth knowing before designing around it.
-\strong{Serial synthesis streams; batched synthesis does not.} Serial
-finishes one chunk at a time in order, so each is emitted the moment it
-is done. Batched runs T3 over \emph{every} chunk before any S3Gen work
-starts, then walks token-length buckets rather than text order -- so
-nothing is emitted until T3 finishes across the whole input, and a
-late-arriving early chunk holds back the ones behind it.
+How much it actually streams depends on \code{strategy}:
+\strong{serial streams, batched does not.} See there.}
 
-Today the strategy is not selectable: it follows the loaded model,
-because the turbo weights have no batched implementation. So the turbo
-model synthesizes serially and streams, and the standard model batches
-and does not. That coupling is incidental rather than intended --
-\code{\link{generate}} handles both models, so the standard weights
-could synthesize serially too, trading throughput for time-to-first-
-audio. Nothing exposes that choice yet.}
+\item{strategy}{Synthesis strategy.
+\describe{
+\item{\code{"auto"}}{(default) Batched where the weights support it,
+serial where they do not. This is what every existing caller
+already gets.}
+\item{\code{"serial"}}{One chunk at a time in text order. Each is
+finished when it is done, so \code{on_chunk} fires immediately and
+audio can start playing after chunk 1. Costs throughput: one CFM
+solve per chunk instead of one per batch. Works on both models.}
+\item{\code{"batched"}}{Runs T3 over \emph{every} chunk, buckets them
+by measured speech-token length, and synthesizes each bucket as one
+padded S3Gen solve. Better throughput. Nothing can be emitted until
+T3 finishes across the whole input, and buckets do not follow text
+order, so \code{on_chunk} fires late and in held-back runs.
+\strong{Standard weights only} -- there is no batched implementation
+for turbo, and asking for it there is an error rather than a silent
+fall back to serial.}
+}
+For a conversational turn, time-to-first-audio is the thing that
+matters and throughput is nearly irrelevant, so \code{"serial"} is the
+one to want. For synthesizing a long document, batched wins outright.}
 
 \item{...}{Synthesis arguments forwarded to the T3 and S3Gen stages, as
 in \code{\link{generate}} (exaggeration, cfg_weight, temperature,

--- a/man/upsample_conformer_encoder_full.Rd
+++ b/man/upsample_conformer_encoder_full.Rd
@@ -3,10 +3,16 @@
 \alias{upsample_conformer_encoder_full}
 \title{Upsample Conformer Encoder}
 \usage{
-upsample_conformer_encoder_full(input_size = 512, output_size = 512,
-                                num_blocks = 6, num_up_blocks = 4, n_head = 8,
-                                n_ffn = 2048, dropout_rate = 0.1,
-                                pre_lookahead_len = 3)
+upsample_conformer_encoder_full(
+  input_size = 512,
+  output_size = 512,
+  num_blocks = 6,
+  num_up_blocks = 4,
+  n_head = 8,
+  n_ffn = 2048,
+  dropout_rate = 0.1,
+  pre_lookahead_len = 3
+)
 }
 \arguments{
 \item{input_size}{Input dimension}


### PR DESCRIPTION
`tts_chunked()` synthesized the whole utterance before returning anything. For a document that's fine. For a conversational turn it means the first word is heard only after the last one is generated, and time-to-first-audio is the thing that matters there.

## Streaming

`on_chunk` is called as each chunk finishes, **always in original chunk order**. The batched path buckets chunks by measured speech-token length and walks the buckets, so chunk 5 can finish before chunk 1 — streaming that to a player in completion order delivers the audio scrambled, which is worse than not streaming. `.emit_ready()` holds a chunk until everything ahead of it exists. Worst case (chunk 1 completes last) it emits nothing until the end, which is exactly the behaviour it replaces: never less correctly, only less eagerly.

`strategy` picks the trade:

- `"serial"` — one chunk at a time in text order, so audio can start after chunk 1. Costs throughput: one CFM solve per chunk instead of one per batch. Works on both models.
- `"batched"` — the existing path. Better throughput, but nothing can be emitted until T3 finishes across the whole input.
- `"auto"` (default) — batched where the weights support it, serial where they do not. What every existing caller already gets.

`"batched"` on turbo weights is an **error**, not a silent fall back to serial. Turbo has no batched implementation, and "asked for batched, got serial" is invisible from the return value.

## The spoken split

A caller that reports how much of a reply was actually heard — a player cut off mid-utterance — needs to know which text piece each chunk said. That mapping was internal and discarded, leaving the caller to recover it by re-splitting the source text.

Re-splitting is wrong in a way that doesn't announce itself. A changed separator, different whitespace, or slightly different model output moves the boundaries, and the transcript gets cut in the wrong place while still reading as a plausible sentence. Nothing errors.

So the split leaves with the audio:

- `on_chunk` receives the text piece that chunk says, **at emit time**. Not at the end, because synthesis can be abandoned part-way, in which case the return value never arrives and the emitted pieces are the only record there is.
- The return gains `chunks` — the same pieces in spoken order, present whether or not a callback was supplied. `character(0)` on empty input rather than absent: one shape that is sometimes NULL is how a `length()` check lands on the wrong branch.

`.emit_ready()` checks 1:1 between the pieces and the audio it labels and stops if they differ. That mapping is the entire reason an index means anything downstream, so a mismatch fails at one line rather than surfacing as speech attributed to the wrong sentence.

`on_chunk`'s arity change is not a break in practice — the callback was added on this branch and has never been released. `serve()` reads only `audio` and `sample_rate`, so it is unaffected by the added field.

## Verified

137 results, all green.

Three mutations, each caught by the assertion written for it:

| Mutation | Caught by |
|---|---|
| `texts[[i]]` → `texts[[i - from + 1L]]` | text follows the absolute index, not the flush offset |
| serial path `chunks[[i]]` → `chunks[[1]]` | emitted text equals the returned split |
| 1:1 guard removed | 3 failures |

The third is the interesting one. Without the guard, too-few pieces emits two chunks and *then* crashes with "subscript out of bounds" — a partial flush followed by an error. Too-many pieces produces **no error at all**: it emits happily against a split that doesn't match. That silent case is what the guard is for, and it's why the check runs before any emission rather than inside the loop.

The out-of-order test pins that text follows the absolute index rather than the flush offset. `texts[[i - from + 1]]` is the natural-looking slip, and under it a resumed flush hands out earlier sentences in the right order — three plausible pieces, all wrong.

The GPU-dependent test files do not run on the development box (the card is occupied by another process), so that arm is unverified here.

## Not included

An `rformat` pass churns 107 lines in `R/resident.R` plus four other files untouched by this branch. Left out deliberately — unrelated normalization would be noise in this diff. `R/tts.R` is already rformat-clean.
